### PR TITLE
feat: add backend services and API routes

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API routes for DocFlow HR."""

--- a/backend/app/api/routes/review.py
+++ b/backend/app/api/routes/review.py
@@ -1,0 +1,596 @@
+"""HR Review Workflow API routes for DocFlow HR.
+
+This module provides endpoints for the document review workflow:
+- GET /review-queue - Get documents pending review
+- POST /documents/{id}/approve - Approve a document
+- POST /documents/{id}/reject - Reject a document
+"""
+
+import logging
+from datetime import datetime
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from app.api.deps import (
+    ActiveUserDep,
+    DBDep,
+    RequestIdDep,
+    require_role,
+)
+from app.core.events import EventType, audit_logger
+from app.core.exceptions import AuthorizationError, NotFoundError
+from app.db.zerodb_client import ZeroDBClient
+from app.schemas.review import (
+    ApproveRequest,
+    RejectRequest,
+    ReviewQueueItem,
+    ReviewQueueResponse,
+    ReviewResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Review Workflow"])
+
+# Roles allowed to perform review actions
+HR_REVIEW_ROLES = ["hr_manager", "hr_admin", "HR Manager", "HR Admin"]
+
+
+async def get_hr_reviewer(
+    current_user: Annotated[dict, Depends(require_role(HR_REVIEW_ROLES))],
+) -> dict:
+    """Dependency to ensure user has HR review permissions.
+
+    Args:
+        current_user: Current authenticated user with HR role
+
+    Returns:
+        Current user data
+    """
+    return current_user
+
+
+HRReviewerDep = Annotated[dict, Depends(get_hr_reviewer)]
+
+
+@router.get(
+    "/review-queue",
+    response_model=ReviewQueueResponse,
+    summary="Get documents pending review",
+    description="Retrieve a paginated list of documents that are pending HR review. "
+    "Only documents belonging to the authenticated user's organization are returned.",
+)
+async def get_review_queue(
+    request: Request,
+    db: DBDep,
+    current_user: ActiveUserDep,
+    request_id: RequestIdDep,
+    page: int = Query(default=1, ge=1, description="Page number"),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    category: Optional[str] = Query(default=None, description="Filter by document category"),
+    submission_channel: Optional[str] = Query(
+        default=None, description="Filter by submission channel"
+    ),
+) -> ReviewQueueResponse:
+    """Get documents pending review for the organization.
+
+    This endpoint retrieves all documents with status "needs_review" that belong
+    to the authenticated user's organization. Results are paginated and can be
+    filtered by category or submission channel.
+
+    Args:
+        request: HTTP request object
+        db: Database client
+        current_user: Authenticated user data
+        request_id: Request tracking ID
+        page: Page number for pagination
+        page_size: Number of items per page
+        category: Optional category filter
+        submission_channel: Optional submission channel filter
+
+    Returns:
+        ReviewQueueResponse with paginated list of documents pending review
+    """
+    org_id = current_user.get("org_id")
+    if not org_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User organization ID not found in token",
+        )
+
+    # Build filters for the query
+    filters: dict = {
+        "org_id": org_id,
+        "status": "needs_review",
+    }
+
+    if category:
+        filters["category"] = category
+    if submission_channel:
+        filters["submission_channel"] = submission_channel
+
+    logger.info(
+        f"Fetching review queue for org {org_id}, page {page}, "
+        f"page_size {page_size}, filters {filters}"
+    )
+
+    try:
+        # Calculate offset for pagination
+        offset = (page - 1) * page_size
+
+        # Query documents needing review
+        documents = await db.table_query(
+            "documents",
+            filters=filters,
+            limit=page_size,
+            offset=offset,
+        )
+
+        # Get total count for pagination (query without limit/offset)
+        # For now, we'll make an additional query or estimate
+        # In production, this should use a count endpoint
+        all_docs = await db.table_query(
+            "documents",
+            filters=filters,
+            limit=1000,  # Max reasonable limit for counting
+            offset=0,
+        )
+        total = len(all_docs)
+
+        # Transform documents to ReviewQueueItem format
+        items = []
+        for doc in documents:
+            # Get employee info if available
+            employee_name = doc.get("employee_name", "Unknown")
+            employee_id = doc.get("employee_id", "")
+
+            # If employee info is not embedded, fetch it
+            if not employee_name or employee_name == "Unknown":
+                if employee_id:
+                    try:
+                        employees = await db.table_query(
+                            "employees",
+                            filters={"id": employee_id},
+                            limit=1,
+                        )
+                        if employees:
+                            emp = employees[0]
+                            employee_name = f"{emp.get('first_name', '')} {emp.get('last_name', '')}".strip()
+                            if not employee_name:
+                                employee_name = emp.get("name", "Unknown")
+                    except Exception as e:
+                        logger.warning(f"Failed to fetch employee {employee_id}: {e}")
+
+            # Parse submitted_at timestamp
+            submitted_at_raw = doc.get("submitted_at") or doc.get("created_at")
+            if isinstance(submitted_at_raw, str):
+                try:
+                    submitted_at = datetime.fromisoformat(submitted_at_raw.replace("Z", "+00:00"))
+                except ValueError:
+                    submitted_at = datetime.utcnow()
+            elif isinstance(submitted_at_raw, datetime):
+                submitted_at = submitted_at_raw
+            else:
+                submitted_at = datetime.utcnow()
+
+            items.append(
+                ReviewQueueItem(
+                    document_id=doc.get("id", ""),
+                    employee_name=employee_name,
+                    employee_id=employee_id,
+                    document_category=doc.get("category", "uncategorized"),
+                    submitted_at=submitted_at,
+                    submission_channel=doc.get("submission_channel", "unknown"),
+                    document_name=doc.get("name") or doc.get("filename"),
+                    file_type=doc.get("file_type") or doc.get("content_type"),
+                )
+            )
+
+        # Calculate pagination metadata
+        total_pages = (total + page_size - 1) // page_size if total > 0 else 0
+        has_next = page < total_pages
+        has_previous = page > 1
+
+        return ReviewQueueResponse(
+            items=items,
+            total=total,
+            page=page,
+            page_size=page_size,
+            has_next=has_next,
+            has_previous=has_previous,
+        )
+
+    except NotFoundError:
+        # Table doesn't exist yet - return empty result
+        return ReviewQueueResponse(
+            items=[],
+            total=0,
+            page=page,
+            page_size=page_size,
+            has_next=False,
+            has_previous=False,
+        )
+
+
+@router.post(
+    "/documents/{document_id}/approve",
+    response_model=ReviewResponse,
+    summary="Approve a document",
+    description="Approve a document that is pending review. "
+    "Requires HR Manager or HR Admin role.",
+)
+async def approve_document(
+    request: Request,
+    document_id: str,
+    db: DBDep,
+    reviewer: HRReviewerDep,
+    request_id: RequestIdDep,
+    body: Optional[ApproveRequest] = None,
+) -> ReviewResponse:
+    """Approve a document pending review.
+
+    This endpoint approves a document, updating its status to "approved",
+    emitting an audit event, and sending a notification to the employee.
+
+    Args:
+        request: HTTP request object
+        document_id: ID of the document to approve
+        db: Database client
+        reviewer: Authenticated HR reviewer
+        request_id: Request tracking ID
+        body: Optional approval request with notes
+
+    Returns:
+        ReviewResponse with the approval details
+
+    Raises:
+        HTTPException: If document not found or doesn't belong to org
+    """
+    org_id = reviewer.get("org_id")
+    user_id = reviewer.get("sub") or reviewer.get("user_id")
+    user_email = reviewer.get("email", "")
+    user_name = reviewer.get("name") or reviewer.get("full_name") or user_email
+
+    if not org_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User organization ID not found in token",
+        )
+
+    logger.info(f"User {user_id} attempting to approve document {document_id}")
+
+    # Fetch the document
+    try:
+        documents = await db.table_query(
+            "documents",
+            filters={"id": document_id},
+            limit=1,
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found",
+        )
+
+    if not documents:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found",
+        )
+
+    document = documents[0]
+
+    # Verify document belongs to the reviewer's organization
+    if document.get("org_id") != org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Document does not belong to your organization",
+        )
+
+    # Verify document is in reviewable state
+    current_status = document.get("status")
+    if current_status not in ("needs_review", "pending", "submitted"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Document cannot be approved. Current status: {current_status}",
+        )
+
+    # Update document status
+    reviewed_at = datetime.utcnow()
+    notes = body.notes if body else None
+
+    update_data = {
+        "status": "approved",
+        "reviewed_by": user_id,
+        "reviewed_by_name": user_name,
+        "reviewed_at": reviewed_at.isoformat(),
+        "review_notes": notes,
+        "updated_at": reviewed_at.isoformat(),
+    }
+
+    try:
+        await db.table_update(
+            "documents",
+            filters={"id": document_id},
+            update=update_data,
+        )
+    except Exception as e:
+        logger.error(f"Failed to update document {document_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update document status",
+        )
+
+    # Emit audit event
+    try:
+        await audit_logger.log_event(
+            event_type=EventType.DOCUMENT_UPDATED,
+            action="document.review.approved",
+            user_id=user_id,
+            user_email=user_email,
+            resource_type="document",
+            resource_id=document_id,
+            details={
+                "previous_status": current_status,
+                "new_status": "approved",
+                "notes": notes,
+                "employee_id": document.get("employee_id"),
+            },
+            request_id=request_id,
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
+        )
+    except Exception as e:
+        logger.warning(f"Failed to log audit event for approval: {e}")
+
+    # Send notification to employee (async, fire-and-forget)
+    try:
+        await _send_review_notification(
+            db=db,
+            employee_id=document.get("employee_id"),
+            document_id=document_id,
+            document_name=document.get("name") or document.get("filename"),
+            action="approved",
+            reviewer_name=user_name,
+            notes=notes,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to send approval notification: {e}")
+
+    logger.info(f"Document {document_id} approved by {user_id}")
+
+    return ReviewResponse(
+        document_id=document_id,
+        status="approved",
+        reviewed_by=user_id,
+        reviewed_by_name=user_name,
+        reviewed_at=reviewed_at,
+        notes=notes,
+    )
+
+
+@router.post(
+    "/documents/{document_id}/reject",
+    response_model=ReviewResponse,
+    summary="Reject a document",
+    description="Reject a document that is pending review. "
+    "Requires HR Manager or HR Admin role. A rejection reason must be provided.",
+)
+async def reject_document(
+    request: Request,
+    document_id: str,
+    body: RejectRequest,
+    db: DBDep,
+    reviewer: HRReviewerDep,
+    request_id: RequestIdDep,
+) -> ReviewResponse:
+    """Reject a document pending review.
+
+    This endpoint rejects a document, updating its status to "rejected",
+    storing the rejection reason, emitting an audit event, and sending
+    a notification to the employee with the rejection reason.
+
+    Args:
+        request: HTTP request object
+        document_id: ID of the document to reject
+        body: Rejection request with reason and optional notes
+        db: Database client
+        reviewer: Authenticated HR reviewer
+        request_id: Request tracking ID
+
+    Returns:
+        ReviewResponse with the rejection details
+
+    Raises:
+        HTTPException: If document not found or doesn't belong to org
+    """
+    org_id = reviewer.get("org_id")
+    user_id = reviewer.get("sub") or reviewer.get("user_id")
+    user_email = reviewer.get("email", "")
+    user_name = reviewer.get("name") or reviewer.get("full_name") or user_email
+
+    if not org_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User organization ID not found in token",
+        )
+
+    logger.info(f"User {user_id} attempting to reject document {document_id}")
+
+    # Fetch the document
+    try:
+        documents = await db.table_query(
+            "documents",
+            filters={"id": document_id},
+            limit=1,
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found",
+        )
+
+    if not documents:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found",
+        )
+
+    document = documents[0]
+
+    # Verify document belongs to the reviewer's organization
+    if document.get("org_id") != org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Document does not belong to your organization",
+        )
+
+    # Verify document is in reviewable state
+    current_status = document.get("status")
+    if current_status not in ("needs_review", "pending", "submitted"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Document cannot be rejected. Current status: {current_status}",
+        )
+
+    # Update document status
+    reviewed_at = datetime.utcnow()
+
+    update_data = {
+        "status": "rejected",
+        "reviewed_by": user_id,
+        "reviewed_by_name": user_name,
+        "reviewed_at": reviewed_at.isoformat(),
+        "rejection_reason": body.reason,
+        "review_notes": body.notes,
+        "updated_at": reviewed_at.isoformat(),
+    }
+
+    try:
+        await db.table_update(
+            "documents",
+            filters={"id": document_id},
+            update=update_data,
+        )
+    except Exception as e:
+        logger.error(f"Failed to update document {document_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update document status",
+        )
+
+    # Emit audit event
+    try:
+        await audit_logger.log_event(
+            event_type=EventType.DOCUMENT_UPDATED,
+            action="document.review.rejected",
+            user_id=user_id,
+            user_email=user_email,
+            resource_type="document",
+            resource_id=document_id,
+            details={
+                "previous_status": current_status,
+                "new_status": "rejected",
+                "rejection_reason": body.reason,
+                "notes": body.notes,
+                "employee_id": document.get("employee_id"),
+            },
+            request_id=request_id,
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
+        )
+    except Exception as e:
+        logger.warning(f"Failed to log audit event for rejection: {e}")
+
+    # Send notification to employee with rejection reason
+    try:
+        await _send_review_notification(
+            db=db,
+            employee_id=document.get("employee_id"),
+            document_id=document_id,
+            document_name=document.get("name") or document.get("filename"),
+            action="rejected",
+            reviewer_name=user_name,
+            notes=body.notes,
+            rejection_reason=body.reason,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to send rejection notification: {e}")
+
+    logger.info(f"Document {document_id} rejected by {user_id}: {body.reason}")
+
+    return ReviewResponse(
+        document_id=document_id,
+        status="rejected",
+        reviewed_by=user_id,
+        reviewed_by_name=user_name,
+        reviewed_at=reviewed_at,
+        notes=body.notes,
+        rejection_reason=body.reason,
+    )
+
+
+async def _send_review_notification(
+    db: ZeroDBClient,
+    employee_id: Optional[str],
+    document_id: str,
+    document_name: Optional[str],
+    action: str,
+    reviewer_name: str,
+    notes: Optional[str] = None,
+    rejection_reason: Optional[str] = None,
+) -> None:
+    """Send a notification to an employee about a document review action.
+
+    This is a helper function that creates a notification record in the database.
+    In a production system, this might also trigger email, push notifications, etc.
+
+    Args:
+        db: Database client
+        employee_id: ID of the employee to notify
+        document_id: ID of the reviewed document
+        document_name: Name of the document
+        action: The review action ("approved" or "rejected")
+        reviewer_name: Name of the reviewer
+        notes: Optional review notes
+        rejection_reason: Reason for rejection (if rejected)
+    """
+    if not employee_id:
+        logger.warning(f"Cannot send notification: no employee_id for document {document_id}")
+        return
+
+    # Build notification message
+    doc_display_name = document_name or f"Document {document_id}"
+
+    if action == "approved":
+        title = "Document Approved"
+        message = f"Your document '{doc_display_name}' has been approved by {reviewer_name}."
+        if notes:
+            message += f" Notes: {notes}"
+    else:
+        title = "Document Rejected"
+        message = f"Your document '{doc_display_name}' has been rejected by {reviewer_name}."
+        if rejection_reason:
+            message += f" Reason: {rejection_reason}"
+        if notes:
+            message += f" Additional notes: {notes}"
+
+    notification_data = {
+        "employee_id": employee_id,
+        "type": "document_review",
+        "title": title,
+        "message": message,
+        "document_id": document_id,
+        "action": action,
+        "reviewer_name": reviewer_name,
+        "read": False,
+        "created_at": datetime.utcnow().isoformat(),
+    }
+
+    try:
+        await db.table_insert("notifications", [notification_data])
+        logger.info(f"Notification sent to employee {employee_id} for document {document_id}")
+    except Exception as e:
+        # Log but don't fail the request if notification fails
+        logger.error(f"Failed to create notification for employee {employee_id}: {e}")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from app.config import settings
+from app.api.routes.review import router as review_router
 
 
 # Create v1 router
@@ -19,9 +20,5 @@ async def v1_root():
     }
 
 
-# Future routers will be included here:
-# from app.api.v1.endpoints import auth, documents, employees, categories
-# router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
-# router.include_router(documents.router, prefix="/documents", tags=["Documents"])
-# router.include_router(employees.router, prefix="/employees", tags=["Employees"])
-# router.include_router(categories.router, prefix="/categories", tags=["Categories"])
+# Include routers
+router.include_router(review_router, prefix="/review", tags=["Review Workflow"])

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,1 +1,31 @@
 """Business logic services for DocFlow HR."""
+
+from app.services.audit import (
+    AuditService,
+    emit_audit_event,
+    emit_document_received,
+    emit_document_version_created,
+    emit_document_review_approved,
+    emit_document_review_rejected,
+    emit_employee_created,
+    emit_employee_updated,
+    emit_legal_hold_created,
+    emit_legal_hold_released,
+)
+from app.services.retention import RetentionService
+
+__all__ = [
+    # Audit Service
+    "AuditService",
+    "emit_audit_event",
+    "emit_document_received",
+    "emit_document_version_created",
+    "emit_document_review_approved",
+    "emit_document_review_rejected",
+    "emit_employee_created",
+    "emit_employee_updated",
+    "emit_legal_hold_created",
+    "emit_legal_hold_released",
+    # Retention Service
+    "RetentionService",
+]

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,543 @@
+"""Audit Event Service for DocFlow HR.
+
+This module provides the core audit functionality for emitting and querying
+immutable audit events. All events are append-only and cannot be modified
+or deleted once created.
+
+Example usage:
+    from app.services.audit import AuditService, emit_audit_event
+
+    # Using the convenience function
+    await emit_audit_event(
+        db=db_client,
+        entity_type="document",
+        entity_id="doc-123",
+        action="document.received",
+        actor_id="user-456",
+        org_id="org-789",
+        metadata={"source": "email", "sender": "hr@company.com"}
+    )
+
+    # Using the service class
+    audit_service = AuditService(db_client)
+    events = await audit_service.query_events(
+        org_id="org-789",
+        entity_type="document",
+        page=1,
+        page_size=20
+    )
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.db.zerodb_client import ZeroDBClient
+from app.schemas.audit import (
+    AuditEvent,
+    AuditEventCreate,
+    AuditEventFilter,
+)
+
+logger = logging.getLogger(__name__)
+
+# Constants
+AUDIT_EVENTS_TABLE = "audit_events"
+
+
+class AuditService:
+    """Service for managing audit events.
+
+    This service provides methods for creating and querying audit events.
+    All events are immutable - once created, they cannot be modified or deleted.
+
+    Attributes:
+        db: ZeroDB client instance for database operations.
+    """
+
+    def __init__(self, db: ZeroDBClient) -> None:
+        """Initialize the audit service.
+
+        Args:
+            db: ZeroDB client instance.
+        """
+        self.db = db
+
+    async def emit_event(
+        self,
+        entity_type: str,
+        entity_id: str,
+        action: str,
+        actor_id: str,
+        org_id: str,
+        actor_email: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> AuditEvent:
+        """Emit a new audit event.
+
+        Creates an immutable audit event record. Once created, the event
+        cannot be modified or deleted.
+
+        Args:
+            entity_type: Type of entity (e.g., "document", "employee").
+            entity_id: Unique identifier of the entity.
+            action: Action performed (e.g., "document.received").
+            actor_id: ID of the user or system performing the action.
+            org_id: Organization ID the event belongs to.
+            actor_email: Optional email of the actor.
+            metadata: Optional additional context about the event.
+
+        Returns:
+            The created AuditEvent.
+
+        Example:
+            ```python
+            event = await audit_service.emit_event(
+                entity_type="document",
+                entity_id="doc-123",
+                action="document.version.created",
+                actor_id="user-456",
+                org_id="org-789",
+                actor_email="john@company.com",
+                metadata={"version": "2.0", "changes": ["Updated policy section"]}
+            )
+            ```
+        """
+        event_id = str(uuid.uuid4())
+        created_at = datetime.utcnow()
+
+        event_data = {
+            "id": event_id,
+            "org_id": org_id,
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "action": action,
+            "actor_id": actor_id,
+            "actor_email": actor_email,
+            "metadata": metadata,
+            "created_at": created_at.isoformat(),
+        }
+
+        logger.info(
+            f"Emitting audit event: {action} for {entity_type}/{entity_id} "
+            f"by actor {actor_id} in org {org_id}"
+        )
+
+        # Insert into database (append-only)
+        await self.db.table_insert(AUDIT_EVENTS_TABLE, [event_data])
+
+        return AuditEvent(
+            id=event_id,
+            org_id=org_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            action=action,
+            actor_id=actor_id,
+            actor_email=actor_email,
+            metadata=metadata,
+            created_at=created_at,
+        )
+
+    async def query_events(
+        self,
+        org_id: str,
+        entity_type: Optional[str] = None,
+        entity_id: Optional[str] = None,
+        action: Optional[str] = None,
+        actor_id: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> Tuple[List[AuditEvent], int]:
+        """Query audit events with optional filters.
+
+        Args:
+            org_id: Organization ID to filter by (required).
+            entity_type: Optional filter by entity type.
+            entity_id: Optional filter by entity ID.
+            action: Optional filter by action type.
+            actor_id: Optional filter by actor ID.
+            start_date: Optional filter for events after this date.
+            end_date: Optional filter for events before this date.
+            page: Page number (1-indexed).
+            page_size: Number of items per page.
+
+        Returns:
+            Tuple of (list of AuditEvents, total count).
+
+        Example:
+            ```python
+            events, total = await audit_service.query_events(
+                org_id="org-789",
+                entity_type="document",
+                action="document.review.approved",
+                start_date=datetime(2024, 1, 1),
+                page=1,
+                page_size=50
+            )
+            ```
+        """
+        # Build filter conditions
+        filters: Dict[str, Any] = {"org_id": org_id}
+
+        if entity_type:
+            filters["entity_type"] = entity_type
+        if entity_id:
+            filters["entity_id"] = entity_id
+        if action:
+            filters["action"] = action
+        if actor_id:
+            filters["actor_id"] = actor_id
+
+        # Date range filters (using ZeroDB comparison operators)
+        if start_date:
+            filters["created_at"] = filters.get("created_at", {})
+            filters["created_at"]["$gte"] = start_date.isoformat()
+        if end_date:
+            filters["created_at"] = filters.get("created_at", {})
+            filters["created_at"]["$lte"] = end_date.isoformat()
+
+        logger.info(f"Querying audit events with filters: {filters}")
+
+        # Calculate offset
+        offset = (page - 1) * page_size
+
+        # Query the database
+        rows = await self.db.table_query(
+            AUDIT_EVENTS_TABLE,
+            filters=filters,
+            limit=page_size,
+            offset=offset,
+        )
+
+        # Get total count (query with same filters but no pagination)
+        # Note: In production, this would use a COUNT query for efficiency
+        all_rows = await self.db.table_query(
+            AUDIT_EVENTS_TABLE,
+            filters=filters,
+            limit=10000,  # Large limit for counting
+            offset=0,
+        )
+        total = len(all_rows)
+
+        # Convert to AuditEvent objects
+        events = [self._row_to_event(row) for row in rows]
+
+        return events, total
+
+    async def get_document_audit_trail(
+        self,
+        org_id: str,
+        document_id: str,
+    ) -> List[AuditEvent]:
+        """Get the complete audit trail for a specific document.
+
+        Returns all audit events for a document in chronological order.
+
+        Args:
+            org_id: Organization ID.
+            document_id: Document ID to get audit trail for.
+
+        Returns:
+            List of AuditEvents in chronological order (oldest first).
+
+        Example:
+            ```python
+            trail = await audit_service.get_document_audit_trail(
+                org_id="org-789",
+                document_id="doc-123"
+            )
+            for event in trail:
+                print(f"{event.created_at}: {event.action} by {event.actor_id}")
+            ```
+        """
+        filters = {
+            "org_id": org_id,
+            "entity_type": "document",
+            "entity_id": document_id,
+        }
+
+        logger.info(f"Getting audit trail for document: {document_id}")
+
+        # Query all events for this document
+        rows = await self.db.table_query(
+            AUDIT_EVENTS_TABLE,
+            filters=filters,
+            limit=10000,  # Get all events
+            offset=0,
+        )
+
+        # Convert to AuditEvent objects
+        events = [self._row_to_event(row) for row in rows]
+
+        # Sort by created_at in chronological order
+        events.sort(key=lambda e: e.created_at)
+
+        return events
+
+    def _row_to_event(self, row: Dict[str, Any]) -> AuditEvent:
+        """Convert a database row to an AuditEvent object.
+
+        Args:
+            row: Dictionary from database query.
+
+        Returns:
+            AuditEvent object.
+        """
+        created_at = row.get("created_at")
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+
+        return AuditEvent(
+            id=row["id"],
+            org_id=row["org_id"],
+            entity_type=row["entity_type"],
+            entity_id=row["entity_id"],
+            action=row["action"],
+            actor_id=row["actor_id"],
+            actor_email=row.get("actor_email"),
+            metadata=row.get("metadata"),
+            created_at=created_at,
+        )
+
+
+# =============================================================================
+# Convenience Functions for Easy Event Emission
+# =============================================================================
+
+
+async def emit_audit_event(
+    db: ZeroDBClient,
+    entity_type: str,
+    entity_id: str,
+    action: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Convenience function to emit an audit event.
+
+    This is a simple wrapper around AuditService.emit_event() for easy
+    use throughout the application.
+
+    Args:
+        db: ZeroDB client instance.
+        entity_type: Type of entity (e.g., "document", "employee").
+        entity_id: Unique identifier of the entity.
+        action: Action performed (e.g., "document.received").
+        actor_id: ID of the user or system performing the action.
+        org_id: Organization ID the event belongs to.
+        actor_email: Optional email of the actor.
+        metadata: Optional additional context about the event.
+
+    Returns:
+        The created AuditEvent.
+
+    Example:
+        ```python
+        from app.services.audit import emit_audit_event
+
+        # In a route handler
+        await emit_audit_event(
+            db=db,
+            entity_type="document",
+            entity_id=doc_id,
+            action="document.received",
+            actor_id=current_user["sub"],
+            org_id=current_user["org_id"],
+            actor_email=current_user.get("email"),
+            metadata={"source": "upload", "filename": "policy.pdf"}
+        )
+        ```
+    """
+    service = AuditService(db)
+    return await service.emit_event(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        action=action,
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+# =============================================================================
+# Pre-defined Event Emitters for Common Actions
+# =============================================================================
+
+
+async def emit_document_received(
+    db: ZeroDBClient,
+    document_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit a document.received event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="document",
+        entity_id=document_id,
+        action="document.received",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+async def emit_document_version_created(
+    db: ZeroDBClient,
+    document_id: str,
+    actor_id: str,
+    org_id: str,
+    version: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit a document.version.created event."""
+    event_metadata = {"version": version}
+    if metadata:
+        event_metadata.update(metadata)
+
+    return await emit_audit_event(
+        db=db,
+        entity_type="document",
+        entity_id=document_id,
+        action="document.version.created",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=event_metadata,
+    )
+
+
+async def emit_document_review_approved(
+    db: ZeroDBClient,
+    document_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit a document.review.approved event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="document",
+        entity_id=document_id,
+        action="document.review.approved",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+async def emit_document_review_rejected(
+    db: ZeroDBClient,
+    document_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit a document.review.rejected event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="document",
+        entity_id=document_id,
+        action="document.review.rejected",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+async def emit_employee_created(
+    db: ZeroDBClient,
+    employee_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit an employee.created event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="employee",
+        entity_id=employee_id,
+        action="employee.created",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+async def emit_employee_updated(
+    db: ZeroDBClient,
+    employee_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit an employee.updated event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="employee",
+        entity_id=employee_id,
+        action="employee.updated",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+async def emit_legal_hold_created(
+    db: ZeroDBClient,
+    legal_hold_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit a legal_hold.created event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="legal_hold",
+        entity_id=legal_hold_id,
+        action="legal_hold.created",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )
+
+
+async def emit_legal_hold_released(
+    db: ZeroDBClient,
+    legal_hold_id: str,
+    actor_id: str,
+    org_id: str,
+    actor_email: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> AuditEvent:
+    """Emit a legal_hold.released event."""
+    return await emit_audit_event(
+        db=db,
+        entity_type="legal_hold",
+        entity_id=legal_hold_id,
+        action="legal_hold.released",
+        actor_id=actor_id,
+        org_id=org_id,
+        actor_email=actor_email,
+        metadata=metadata,
+    )

--- a/backend/app/services/retention.py
+++ b/backend/app/services/retention.py
@@ -1,0 +1,424 @@
+"""Retention policy service for DocFlow HR.
+
+This service handles document retention calculations and deletion scheduling
+based on state-specific retention requirements. It integrates with legal hold
+service to ensure documents under hold are never deleted prematurely.
+
+Compliance Notes:
+- Retention periods vary by state and document type
+- Federal baseline: EEOC requires 1 year; FLSA requires 3 years for payroll
+- State overrides: Many states have longer requirements (e.g., CA requires 4 years)
+- Legal holds ALWAYS take precedence over retention policies
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta
+from typing import Optional
+
+from app.core.events import EventType
+from app.core.exceptions import NotFoundError, ValidationError, ConflictError
+from app.db.zerodb_client import ZeroDBClient
+from app.schemas.retention import (
+    RetentionCalculation,
+    RetentionPolicy,
+    RetentionScheduleResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RetentionService:
+    """Service for managing document retention policies and schedules."""
+
+    def __init__(self, db: ZeroDBClient):
+        """Initialize retention service.
+
+        Args:
+            db: ZeroDB client for database operations
+        """
+        self.db = db
+
+    async def calculate_retention_date(
+        self,
+        employee_id: str,
+        document_id: str,
+        org_id: str,
+    ) -> RetentionCalculation:
+        """Calculate deletion date for a document based on retention policy.
+
+        Business Logic:
+        1. Fetch employee to get state_of_work and termination_date
+        2. Fetch document to get category
+        3. Look up retention policy for state + category
+        4. Calculate deletion_scheduled_at = termination_date + retention_days
+        5. Check if document is under legal hold
+        6. If under hold, deletion_scheduled_at = None (blocked)
+
+        Args:
+            employee_id: Employee identifier
+            document_id: Document identifier
+            org_id: Organization identifier
+
+        Returns:
+            RetentionCalculation with deletion date and hold status
+
+        Raises:
+            NotFoundError: If employee, document, or policy not found
+            ValidationError: If employee not terminated (no termination_date)
+        """
+        logger.info(f"Calculating retention for document {document_id}, employee {employee_id}")
+
+        # 1. Fetch employee
+        employees = await self.db.table_query(
+            "employees",
+            filters={"id": employee_id, "org_id": org_id},
+            limit=1,
+        )
+        if not employees:
+            raise NotFoundError(
+                message=f"Employee {employee_id} not found",
+                resource_type="employee",
+                resource_id=employee_id,
+            )
+        employee = employees[0]
+
+        # 2. Fetch document
+        documents = await self.db.table_query(
+            "documents",
+            filters={"id": document_id, "org_id": org_id},
+            limit=1,
+        )
+        if not documents:
+            raise NotFoundError(
+                message=f"Document {document_id} not found",
+                resource_type="document",
+                resource_id=document_id,
+            )
+        document = documents[0]
+
+        state_code = employee.get("state_of_work")
+        termination_date = employee.get("termination_date")
+        document_category = document.get("category")
+
+        if not state_code:
+            raise ValidationError(
+                message="Employee has no state_of_work defined",
+                details=[{"field": "state_of_work", "message": "Required for retention calculation"}],
+            )
+
+        # 3. Look up retention policy
+        policies = await self.db.table_query(
+            "retention_policies",
+            filters={
+                "org_id": org_id,
+                "state_code": state_code,
+                "document_category": document_category,
+            },
+            limit=1,
+        )
+
+        if not policies:
+            raise NotFoundError(
+                message=f"No retention policy found for state {state_code}, category {document_category}",
+                resource_type="retention_policy",
+            )
+        policy = policies[0]
+        retention_days = policy.get("retention_days", 0)
+
+        # 4. Calculate deletion date
+        deletion_scheduled_at = None
+        if termination_date:
+            # termination_date might be string, convert to date
+            if isinstance(termination_date, str):
+                from datetime import date
+                term_date = date.fromisoformat(termination_date)
+            else:
+                term_date = termination_date
+
+            # Add retention days
+            deletion_date = term_date + timedelta(days=retention_days)
+            deletion_scheduled_at = datetime.combine(deletion_date, datetime.min.time())
+
+        # 5. Check legal holds
+        legal_holds = await self.db.table_query(
+            "legal_holds",
+            filters={"org_id": org_id, "status": "active"},
+        )
+
+        under_legal_hold = False
+        legal_hold_count = 0
+
+        for hold in legal_holds:
+            if self._document_matches_hold(document, employee, hold):
+                under_legal_hold = True
+                legal_hold_count += 1
+
+        # If under hold, block deletion
+        if under_legal_hold:
+            deletion_scheduled_at = None
+
+        return RetentionCalculation(
+            document_id=document_id,
+            employee_id=employee_id,
+            state_code=state_code,
+            retention_days=retention_days,
+            termination_date=termination_date,
+            deletion_scheduled_at=deletion_scheduled_at,
+            under_legal_hold=under_legal_hold,
+            legal_hold_count=legal_hold_count,
+        )
+
+    async def schedule_deletion(
+        self,
+        document_id: str,
+        deletion_scheduled_at: datetime,
+        org_id: str,
+        user_id: str,
+        reason: Optional[str] = None,
+    ) -> RetentionScheduleResponse:
+        """Schedule a document for deletion.
+
+        This operation:
+        1. Checks if document exists
+        2. Verifies document is NOT under legal hold
+        3. Updates document.deletion_scheduled_at
+        4. Logs audit event
+
+        Args:
+            document_id: Document identifier
+            deletion_scheduled_at: When to delete the document
+            org_id: Organization identifier
+            user_id: User scheduling the deletion
+            reason: Business justification (optional)
+
+        Returns:
+            RetentionScheduleResponse with scheduling details
+
+        Raises:
+            NotFoundError: If document doesn't exist
+            ConflictError: If document is under legal hold
+        """
+        logger.info(f"Scheduling deletion for document {document_id} at {deletion_scheduled_at}")
+
+        # 1. Fetch document
+        documents = await self.db.table_query(
+            "documents",
+            filters={"id": document_id, "org_id": org_id},
+            limit=1,
+        )
+        if not documents:
+            raise NotFoundError(
+                message=f"Document {document_id} not found",
+                resource_type="document",
+                resource_id=document_id,
+            )
+        document = documents[0]
+
+        # 2. Check legal holds
+        legal_holds = await self.db.table_query(
+            "legal_holds",
+            filters={"org_id": org_id, "status": "active"},
+        )
+
+        # Need employee data to check holds
+        employee_id = document.get("employee_id")
+        employee = None
+        if employee_id:
+            employees = await self.db.table_query(
+                "employees",
+                filters={"id": employee_id, "org_id": org_id},
+                limit=1,
+            )
+            if employees:
+                employee = employees[0]
+
+        for hold in legal_holds:
+            if self._document_matches_hold(document, employee, hold):
+                # Document is under legal hold - CANNOT schedule deletion
+                raise ConflictError(
+                    message=f"Document is under legal hold '{hold.get('name')}' and cannot be scheduled for deletion",
+                    details=[
+                        {
+                            "field": "legal_hold",
+                            "message": "Release legal hold before scheduling deletion",
+                            "hold_id": hold.get("id"),
+                            "hold_name": hold.get("name"),
+                        }
+                    ],
+                )
+
+        # 3. Update document
+        await self.db.table_update(
+            "documents",
+            filters={"id": document_id, "org_id": org_id},
+            update={
+                "deletion_scheduled_at": deletion_scheduled_at.isoformat(),
+                "updated_at": datetime.utcnow().isoformat(),
+            },
+        )
+
+        # 4. Log audit event
+        await self.db.event_create(
+            event_type="retention.scheduled",
+            entity_type="document",
+            entity_id=document_id,
+            actor_id=user_id,
+            actor_type="user",
+            payload={
+                "deletion_scheduled_at": deletion_scheduled_at.isoformat(),
+                "reason": reason,
+                "document_category": document.get("category"),
+                "employee_id": employee_id,
+            },
+        )
+
+        logger.info(f"Document {document_id} scheduled for deletion at {deletion_scheduled_at}")
+
+        return RetentionScheduleResponse(
+            document_id=document_id,
+            deletion_scheduled_at=deletion_scheduled_at,
+            under_legal_hold=False,
+            scheduled_by=user_id,
+            scheduled_at=datetime.utcnow(),
+            message="Document successfully scheduled for deletion",
+        )
+
+    def _document_matches_hold(
+        self,
+        document: dict,
+        employee: Optional[dict],
+        legal_hold: dict,
+    ) -> bool:
+        """Check if a document matches a legal hold's scope.
+
+        Args:
+            document: Document data
+            employee: Employee data (may be None)
+            legal_hold: Legal hold definition
+
+        Returns:
+            True if document is affected by this hold
+        """
+        scope_type = legal_hold.get("scope_type")
+        scope_value = legal_hold.get("scope_value")
+
+        if scope_type == "employee":
+            # Hold applies to specific employee
+            return employee and employee.get("id") == scope_value
+
+        elif scope_type == "department":
+            # Hold applies to entire department
+            return employee and employee.get("department") == scope_value
+
+        elif scope_type == "document_category":
+            # Hold applies to document category
+            return document.get("category") == scope_value
+
+        elif scope_type == "date_range":
+            # Hold applies to documents created in date range
+            # scope_value format: "2023-01-01:2023-12-31"
+            try:
+                start_str, end_str = scope_value.split(":")
+                start_date = datetime.fromisoformat(start_str)
+                end_date = datetime.fromisoformat(end_str)
+
+                doc_created_at = document.get("created_at")
+                if isinstance(doc_created_at, str):
+                    doc_created_at = datetime.fromisoformat(doc_created_at)
+
+                return start_date <= doc_created_at <= end_date
+            except (ValueError, AttributeError):
+                logger.warning(f"Invalid date_range scope: {scope_value}")
+                return False
+
+        return False
+
+    async def get_retention_policy(
+        self,
+        state_code: str,
+        document_category: str,
+        org_id: str,
+    ) -> Optional[RetentionPolicy]:
+        """Get retention policy for a state and document category.
+
+        Args:
+            state_code: Two-letter state code
+            document_category: Document category name
+            org_id: Organization identifier
+
+        Returns:
+            RetentionPolicy if found, None otherwise
+        """
+        policies = await self.db.table_query(
+            "retention_policies",
+            filters={
+                "org_id": org_id,
+                "state_code": state_code.upper(),
+                "document_category": document_category,
+            },
+            limit=1,
+        )
+
+        if policies:
+            return RetentionPolicy(**policies[0])
+        return None
+
+    async def seed_default_policies(self, org_id: str, user_id: str) -> list[RetentionPolicy]:
+        """Seed default state-based retention policies.
+
+        Default retention periods (post-termination):
+        - Florida: 5 years (1,825 days)
+        - Texas: 4 years (1,460 days)
+        - Arizona: 4 years (1,460 days)
+        - North Carolina: 3 years (1,095 days)
+        - Tennessee: 3 years (1,095 days)
+
+        Note: These apply to all document categories. Override specific
+        categories (e.g., payroll, I-9) with longer periods if needed.
+
+        Args:
+            org_id: Organization identifier
+            user_id: User creating the policies
+
+        Returns:
+            List of created retention policies
+        """
+        state_policies = [
+            {"state": "FL", "years": 5, "days": 1825},
+            {"state": "TX", "years": 4, "days": 1460},
+            {"state": "AZ", "years": 4, "days": 1460},
+            {"state": "NC", "years": 3, "days": 1095},
+            {"state": "TN", "years": 3, "days": 1095},
+        ]
+
+        # Common HR document categories
+        categories = [
+            "onboarding",
+            "tax_forms",
+            "benefits",
+            "performance",
+            "termination",
+            "general",
+        ]
+
+        created_policies = []
+
+        for state_policy in state_policies:
+            for category in categories:
+                policy_id = str(uuid.uuid4())
+                policy_data = {
+                    "id": policy_id,
+                    "org_id": org_id,
+                    "state_code": state_policy["state"],
+                    "document_category": category,
+                    "retention_days": state_policy["days"],
+                    "created_at": datetime.utcnow().isoformat(),
+                    "created_by": user_id,
+                }
+
+                await self.db.table_insert("retention_policies", [policy_data])
+                created_policies.append(RetentionPolicy(**policy_data))
+
+        logger.info(f"Seeded {len(created_policies)} retention policies for org {org_id}")
+        return created_policies


### PR DESCRIPTION
## Summary
- Add audit trail logging and compliance reporting service
- Add retention policy enforcement service
- Add document review workflow API endpoints
- Update main router with new route registrations

## Test plan
- [ ] Verify services import correctly
- [ ] Test API routes with sample requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements HR review workflow endpoints and foundational compliance services.
> 
> - **Review API**: Adds `GET /v1/review/review-queue`, `POST /v1/review/documents/{id}/approve`, and `POST /v1/review/documents/{id}/reject` with org scoping, HR role checks, status updates, audit logging, and employee notifications
> - **Router**: Registers the review router under `v1` (`router.include_router(review_router, prefix="/review")`)
> - **Audit Service**: New `AuditService` to emit/query immutable events (`audit_events`), plus convenience emitters (e.g., `document.review.approved/rejected`, `employee.created/updated`)
> - **Retention Service**: New `RetentionService` to calculate deletion dates, enforce legal holds, schedule deletions (with audit events), and seed default state-based policies
> - **Exports**: Updates `app/services/__init__.py` to expose audit/retention services
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4b166d09f6b3f4d434cbe91d78fa1d9c482e47b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->