### PR TITLE
feat: add frontend components and update settings pages

### DIFF
--- a/frontend/app/(settings)/settings/legal-holds/page.tsx
+++ b/frontend/app/(settings)/settings/legal-holds/page.tsx
@@ -109,7 +109,7 @@ export default function LegalHoldsPage() {
                   <TableBody>
                     {holds.map((hold) => (
                       <TableRow key={hold.id}>
-                        <TableCell className="font-medium">{hold.title}</TableCell>
+                        <TableCell className="font-medium">{hold.title || hold.name}</TableCell>
                         <TableCell>
                           <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${
                             hold.status === 'active'

--- a/frontend/app/(settings)/settings/retention/page.tsx
+++ b/frontend/app/(settings)/settings/retention/page.tsx
@@ -145,7 +145,7 @@ export default function RetentionPage() {
                         <TableCell>
                           <div className="flex items-center gap-2">
                             <Calendar className="h-4 w-4 text-slate-400" />
-                            <span>{formatDays(policy.retention_period_days)}</span>
+                            <span>{formatDays(policy.retention_period_days ?? policy.retention_days)}</span>
                           </div>
                         </TableCell>
                         <TableCell>

--- a/frontend/components/document-card.tsx
+++ b/frontend/components/document-card.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { FileText, Calendar, User, Download } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { StatusBadge } from '@/components/status-badge';
+import type { Document, DocumentWithEmployee } from '@/lib/supabase/types';
+
+export interface DocumentCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The document data to display */
+  document: Document | DocumentWithEmployee;
+  /** Link to view document details */
+  href?: string;
+  /** Whether to show the employee name (if available) */
+  showEmployee?: boolean;
+  /** Whether to show download button */
+  showDownload?: boolean;
+  /** Callback when download is clicked */
+  onDownload?: (document: Document | DocumentWithEmployee) => void;
+  /** Whether the card is in a loading state */
+  isLoading?: boolean;
+  /** Compact mode for list views */
+  compact?: boolean;
+}
+
+/**
+ * DocumentCard - Displays document information in a card format
+ *
+ * @example
+ * ```tsx
+ * <DocumentCard
+ *   document={doc}
+ *   href={`/hr/documents/${doc.id}`}
+ *   showEmployee
+ * />
+ * ```
+ */
+export function DocumentCard({
+  className,
+  document,
+  href,
+  showEmployee = false,
+  showDownload = false,
+  onDownload,
+  isLoading = false,
+  compact = false,
+  ...props
+}: DocumentCardProps) {
+  const employee = 'employee' in document ? document.employee : null;
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  };
+
+  const formatDate = (dateString: string): string => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <Card className={cn('animate-pulse', className)} {...props}>
+        <CardHeader className={compact ? 'pb-2' : undefined}>
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-slate-200 rounded" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 bg-slate-200 rounded w-3/4" />
+              <div className="h-3 bg-slate-200 rounded w-1/2" />
+            </div>
+          </div>
+        </CardHeader>
+        {!compact && (
+          <CardContent>
+            <div className="h-3 bg-slate-200 rounded w-full" />
+          </CardContent>
+        )}
+      </Card>
+    );
+  }
+
+  const cardContent = (
+    <>
+      <CardHeader className={compact ? 'pb-2' : undefined}>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3 min-w-0 flex-1">
+            <div
+              className="w-10 h-10 bg-slate-100 rounded flex items-center justify-center flex-shrink-0"
+              aria-hidden="true"
+            >
+              <FileText className="h-5 w-5 text-slate-400" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="font-medium text-slate-900 truncate">
+                {document.type || 'Document'}
+              </h3>
+              <p className="text-sm text-slate-500 truncate">
+                {document.file_name}
+              </p>
+            </div>
+          </div>
+          <StatusBadge status={document.status} />
+        </div>
+      </CardHeader>
+
+      {!compact && (
+        <CardContent className="space-y-2">
+          {showEmployee && employee && (
+            <div className="flex items-center gap-2 text-sm text-slate-600">
+              <User className="h-4 w-4" aria-hidden="true" />
+              <span>{employee.name}</span>
+              {employee.email && (
+                <span className="text-slate-400">({employee.email})</span>
+              )}
+            </div>
+          )}
+          <div className="flex items-center gap-4 text-sm text-slate-500">
+            <div className="flex items-center gap-1">
+              <Calendar className="h-4 w-4" aria-hidden="true" />
+              <span>{formatDate(document.created_at)}</span>
+            </div>
+            <span className="text-slate-300">|</span>
+            <span>{formatFileSize(document.file_size)}</span>
+            <span className="text-slate-300">|</span>
+            <span className="capitalize">{document.source}</span>
+          </div>
+          {document.notes && (
+            <p className="text-sm text-slate-600 line-clamp-2">
+              {document.notes}
+            </p>
+          )}
+        </CardContent>
+      )}
+
+      {showDownload && (
+        <CardFooter className="pt-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onDownload?.(document);
+            }}
+            aria-label={`Download ${document.file_name}`}
+          >
+            <Download className="h-4 w-4 mr-2" aria-hidden="true" />
+            Download
+          </Button>
+        </CardFooter>
+      )}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block">
+        <Card
+          className={cn(
+            'hover:border-blue-600 transition-colors cursor-pointer',
+            className
+          )}
+          {...props}
+        >
+          {cardContent}
+        </Card>
+      </Link>
+    );
+  }
+
+  return (
+    <Card className={className} {...props}>
+      {cardContent}
+    </Card>
+  );
+}
+
+/**
+ * DocumentCardSkeleton - Loading skeleton for DocumentCard
+ */
+export function DocumentCardSkeleton({
+  className,
+  compact = false,
+}: {
+  className?: string;
+  compact?: boolean;
+}) {
+  return <DocumentCard document={{} as Document} isLoading className={className} compact={compact} />;
+}

--- a/frontend/components/file-uploader.tsx
+++ b/frontend/components/file-uploader.tsx
@@ -1,0 +1,435 @@
+'use client';
+
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+import { Upload, X, FileIcon, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+
+export interface FileWithPreview extends File {
+  preview?: string;
+  id?: string;
+}
+
+export interface UploadedFile {
+  file: FileWithPreview;
+  progress: number;
+  status: 'pending' | 'uploading' | 'complete' | 'error';
+  error?: string;
+}
+
+export interface FileUploaderProps {
+  /** Accepted file types (e.g., '.pdf,image/*') */
+  accept?: string;
+  /** Maximum file size in bytes (default: 10MB) */
+  maxSize?: number;
+  /** Maximum number of files (default: 10) */
+  maxFiles?: number;
+  /** Whether multiple files can be selected */
+  multiple?: boolean;
+  /** Whether the uploader is disabled */
+  disabled?: boolean;
+  /** Callback when files are added */
+  onFilesAdded?: (files: FileWithPreview[]) => void;
+  /** Callback when a file is removed */
+  onFileRemoved?: (file: FileWithPreview, index: number) => void;
+  /** Callback when upload starts */
+  onUploadStart?: (files: FileWithPreview[]) => void;
+  /** Custom upload handler (if not provided, files are just collected) */
+  onUpload?: (file: FileWithPreview) => Promise<void>;
+  /** Custom validation function */
+  validate?: (file: File) => string | null;
+  /** Custom class name */
+  className?: string;
+  /** Show file previews */
+  showPreviews?: boolean;
+  /** Current files (controlled mode) */
+  files?: UploadedFile[];
+  /** Set files (controlled mode) */
+  setFiles?: React.Dispatch<React.SetStateAction<UploadedFile[]>>;
+}
+
+const DEFAULT_MAX_SIZE = 10 * 1024 * 1024; // 10MB
+const DEFAULT_MAX_FILES = 10;
+const DEFAULT_ACCEPT = '.pdf,image/*';
+
+/**
+ * FileUploader - Drag-and-drop file upload component with progress tracking
+ *
+ * @example
+ * ```tsx
+ * <FileUploader
+ *   accept=".pdf,image/*"
+ *   maxSize={10 * 1024 * 1024}
+ *   multiple
+ *   onFilesAdded={(files) => console.log(files)}
+ * />
+ * ```
+ */
+export function FileUploader({
+  accept = DEFAULT_ACCEPT,
+  maxSize = DEFAULT_MAX_SIZE,
+  maxFiles = DEFAULT_MAX_FILES,
+  multiple = true,
+  disabled = false,
+  onFilesAdded,
+  onFileRemoved,
+  onUploadStart,
+  onUpload,
+  validate,
+  className,
+  showPreviews = true,
+  files: controlledFiles,
+  setFiles: setControlledFiles,
+}: FileUploaderProps) {
+  const [internalFiles, setInternalFiles] = useState<UploadedFile[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Use controlled or uncontrolled mode
+  const files = controlledFiles ?? internalFiles;
+  const setFiles = setControlledFiles ?? setInternalFiles;
+
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  };
+
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      // Check custom validation first
+      if (validate) {
+        const customError = validate(file);
+        if (customError) return customError;
+      }
+
+      // Check file type
+      const acceptedTypes = accept.split(',').map((t) => t.trim());
+      const isAccepted = acceptedTypes.some((type) => {
+        if (type.startsWith('.')) {
+          return file.name.toLowerCase().endsWith(type.toLowerCase());
+        }
+        if (type.endsWith('/*')) {
+          return file.type.startsWith(type.slice(0, -1));
+        }
+        return file.type === type;
+      });
+
+      if (!isAccepted) {
+        return `File type not accepted. Please use: ${accept}`;
+      }
+
+      // Check file size
+      if (file.size > maxSize) {
+        return `File too large. Maximum size is ${formatFileSize(maxSize)}`;
+      }
+
+      return null;
+    },
+    [accept, maxSize, validate]
+  );
+
+  const processFiles = useCallback(
+    (newFiles: File[]) => {
+      setError(null);
+
+      // Check max files limit
+      if (files.length + newFiles.length > maxFiles) {
+        setError(`Maximum ${maxFiles} files allowed`);
+        return;
+      }
+
+      const validFiles: FileWithPreview[] = [];
+      const errors: string[] = [];
+
+      newFiles.forEach((file) => {
+        const validationError = validateFile(file);
+        if (validationError) {
+          errors.push(`${file.name}: ${validationError}`);
+        } else {
+          const fileWithPreview = file as FileWithPreview;
+          fileWithPreview.id = crypto.randomUUID();
+          if (file.type.startsWith('image/')) {
+            fileWithPreview.preview = URL.createObjectURL(file);
+          }
+          validFiles.push(fileWithPreview);
+        }
+      });
+
+      if (errors.length > 0) {
+        setError(errors.join('\n'));
+      }
+
+      if (validFiles.length > 0) {
+        const uploadedFiles: UploadedFile[] = validFiles.map((file) => ({
+          file,
+          progress: 0,
+          status: 'pending' as const,
+        }));
+
+        setFiles((prev) => [...prev, ...uploadedFiles]);
+        onFilesAdded?.(validFiles);
+
+        if (onUpload) {
+          onUploadStart?.(validFiles);
+          // Start uploads
+          uploadedFiles.forEach(async (uploadedFile, index) => {
+            const fileIndex = files.length + index;
+            setFiles((prev) =>
+              prev.map((f, i) =>
+                i === fileIndex ? { ...f, status: 'uploading' as const, progress: 0 } : f
+              )
+            );
+
+            try {
+              await onUpload(uploadedFile.file);
+              setFiles((prev) =>
+                prev.map((f, i) =>
+                  i === fileIndex ? { ...f, status: 'complete' as const, progress: 100 } : f
+                )
+              );
+            } catch (err) {
+              setFiles((prev) =>
+                prev.map((f, i) =>
+                  i === fileIndex
+                    ? {
+                        ...f,
+                        status: 'error' as const,
+                        error: err instanceof Error ? err.message : 'Upload failed',
+                      }
+                    : f
+                )
+              );
+            }
+          });
+        }
+      }
+    },
+    [files.length, maxFiles, validateFile, setFiles, onFilesAdded, onUpload, onUploadStart]
+  );
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      if (!disabled) {
+        setIsDragging(true);
+      }
+    },
+    [disabled]
+  );
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      if (disabled) return;
+
+      const droppedFiles = Array.from(e.dataTransfer.files);
+      processFiles(droppedFiles);
+    },
+    [disabled, processFiles]
+  );
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        const selectedFiles = Array.from(e.target.files);
+        processFiles(selectedFiles);
+        // Reset input
+        e.target.value = '';
+      }
+    },
+    [processFiles]
+  );
+
+  const removeFile = useCallback(
+    (index: number) => {
+      const file = files[index];
+      if (file.file.preview) {
+        URL.revokeObjectURL(file.file.preview);
+      }
+      setFiles((prev) => prev.filter((_, i) => i !== index));
+      onFileRemoved?.(file.file, index);
+    },
+    [files, setFiles, onFileRemoved]
+  );
+
+  const handleBrowseClick = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleBrowseClick();
+      }
+    },
+    [handleBrowseClick]
+  );
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Drop zone */}
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-label="Upload files by dropping them here or clicking to browse"
+        aria-disabled={disabled}
+        className={cn(
+          'border-2 border-dashed rounded-lg p-8 md:p-12 text-center transition-colors cursor-pointer',
+          isDragging && !disabled
+            ? 'border-blue-600 bg-blue-50'
+            : 'border-slate-300 hover:border-blue-600',
+          disabled && 'opacity-50 cursor-not-allowed hover:border-slate-300'
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={handleBrowseClick}
+        onKeyDown={handleKeyDown}
+      >
+        <Upload
+          className={cn(
+            'h-12 w-12 mx-auto mb-4',
+            isDragging ? 'text-blue-600' : 'text-slate-400'
+          )}
+          aria-hidden="true"
+        />
+        <p className="text-lg font-medium text-slate-900 mb-2">
+          {isDragging ? 'Drop files here' : 'Drag and drop files here'}
+        </p>
+        <p className="text-sm text-slate-600 mb-4">or click to browse from your device</p>
+        <Input
+          ref={inputRef}
+          type="file"
+          multiple={multiple}
+          accept={accept}
+          onChange={handleFileInput}
+          disabled={disabled}
+          className="hidden"
+          id="file-upload"
+          aria-describedby="file-upload-description"
+        />
+        <Label htmlFor="file-upload" className="sr-only">
+          Choose files to upload
+        </Label>
+        <Button type="button" variant="outline" disabled={disabled} asChild>
+          <span>Browse Files</span>
+        </Button>
+        <p id="file-upload-description" className="text-xs text-slate-500 mt-4">
+          Supports {accept.replace(/,/g, ', ')} up to {formatFileSize(maxSize)} each
+          {multiple && ` (max ${maxFiles} files)`}
+        </p>
+      </div>
+
+      {/* Error message */}
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800"
+        >
+          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" aria-hidden="true" />
+          <span className="whitespace-pre-line">{error}</span>
+        </div>
+      )}
+
+      {/* File list */}
+      {showPreviews && files.length > 0 && (
+        <div className="space-y-2">
+          <Label>Selected Files ({files.length})</Label>
+          <ul className="space-y-2" role="list" aria-label="Selected files">
+            {files.map((uploadedFile, index) => (
+              <li
+                key={uploadedFile.file.id || index}
+                className="flex items-center gap-3 p-3 bg-slate-50 rounded-lg"
+              >
+                {/* Preview or icon */}
+                {uploadedFile.file.preview ? (
+                  <img
+                    src={uploadedFile.file.preview}
+                    alt={`Preview of ${uploadedFile.file.name}`}
+                    className="w-12 h-12 object-cover rounded"
+                  />
+                ) : (
+                  <div
+                    className="w-12 h-12 bg-slate-200 rounded flex items-center justify-center"
+                    aria-hidden="true"
+                  >
+                    <FileIcon className="h-6 w-6 text-slate-500" />
+                  </div>
+                )}
+
+                {/* File info */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-slate-900 truncate">
+                    {uploadedFile.file.name}
+                  </p>
+                  <p className="text-xs text-slate-500">
+                    {formatFileSize(uploadedFile.file.size)}
+                  </p>
+
+                  {/* Progress bar */}
+                  {uploadedFile.status === 'uploading' && (
+                    <Progress
+                      value={uploadedFile.progress}
+                      className="h-1 mt-2"
+                      aria-label={`Upload progress: ${uploadedFile.progress}%`}
+                    />
+                  )}
+
+                  {/* Error message */}
+                  {uploadedFile.status === 'error' && uploadedFile.error && (
+                    <p className="text-xs text-red-600 mt-1">{uploadedFile.error}</p>
+                  )}
+                </div>
+
+                {/* Status indicator */}
+                <div className="flex items-center gap-2">
+                  {uploadedFile.status === 'uploading' && (
+                    <Loader2
+                      className="h-5 w-5 text-blue-600 animate-spin"
+                      aria-label="Uploading"
+                    />
+                  )}
+                  {uploadedFile.status === 'complete' && (
+                    <CheckCircle className="h-5 w-5 text-green-600" aria-label="Upload complete" />
+                  )}
+                  {uploadedFile.status === 'error' && (
+                    <AlertCircle className="h-5 w-5 text-red-600" aria-label="Upload failed" />
+                  )}
+
+                  {/* Remove button */}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeFile(index)}
+                    disabled={uploadedFile.status === 'uploading'}
+                    aria-label={`Remove ${uploadedFile.file.name}`}
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FileUploader;

--- a/frontend/components/status-badge.tsx
+++ b/frontend/components/status-badge.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import type { DocumentStatus } from '@/lib/supabase/types';
+
+const statusBadgeVariants = cva(
+  'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+  {
+    variants: {
+      status: {
+        received: 'bg-blue-100 text-blue-800',
+        in_review: 'bg-yellow-100 text-yellow-800',
+        approved: 'bg-green-100 text-green-800',
+        rejected: 'bg-red-100 text-red-800',
+        expired: 'bg-slate-100 text-slate-800',
+        on_hold: 'bg-purple-100 text-purple-800',
+      },
+      size: {
+        sm: 'px-2 py-0.5 text-xs',
+        default: 'px-2.5 py-1 text-xs',
+        lg: 'px-3 py-1.5 text-sm',
+      },
+    },
+    defaultVariants: {
+      status: 'received',
+      size: 'default',
+    },
+  }
+);
+
+export interface StatusBadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof statusBadgeVariants> {
+  /** The document status to display */
+  status: DocumentStatus;
+  /** Whether to show the status label or use custom children */
+  showLabel?: boolean;
+}
+
+const statusLabels: Record<DocumentStatus, string> = {
+  received: 'Received',
+  in_review: 'In Review',
+  approved: 'Approved',
+  rejected: 'Rejected',
+  expired: 'Expired',
+  on_hold: 'On Hold',
+};
+
+/**
+ * StatusBadge - Displays document status with appropriate styling
+ *
+ * @example
+ * ```tsx
+ * <StatusBadge status="approved" />
+ * <StatusBadge status="in_review" size="lg" />
+ * <StatusBadge status="rejected" showLabel={false}>Custom Label</StatusBadge>
+ * ```
+ */
+export function StatusBadge({
+  className,
+  status,
+  size,
+  showLabel = true,
+  children,
+  ...props
+}: StatusBadgeProps) {
+  return (
+    <span
+      role="status"
+      aria-label={`Status: ${statusLabels[status]}`}
+      className={cn(statusBadgeVariants({ status, size }), className)}
+      {...props}
+    >
+      {showLabel ? statusLabels[status] : children}
+    </span>
+  );
+}
+
+export { statusBadgeVariants, statusLabels };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2009,6 +2009,7 @@
       "version": "18.2.22",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.22.tgz",
       "integrity": "sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2019,6 +2020,7 @@
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2160,6 +2162,7 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2533,6 +2536,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -3276,6 +3280,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -3429,7 +3434,8 @@
     "node_modules/embla-carousel": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.0.tgz",
-      "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA=="
+      "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA==",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.3.0",
@@ -3661,6 +3667,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
       "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3815,6 +3822,7 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5635,6 +5643,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -5813,6 +5822,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5837,6 +5847,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -5849,6 +5860,7 @@
       "version": "7.53.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
       "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6622,6 +6634,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
       "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6842,6 +6855,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary
- Add document-card component for displaying document metadata
- Add file-uploader with drag-and-drop and progress tracking
- Add status-badge component for visual document state indicators
- Update legal-holds and retention settings pages

## Test plan
- [ ] Verify components render correctly
- [ ] Test file upload functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds reusable UI building blocks for document lists and uploading, plus small data-handling tweaks in settings.
> 
> - New `DocumentCard` component with status display (`StatusBadge`), optional employee/details, compact mode, skeleton, and optional download action
> - New `FileUploader` with drag-and-drop, previews, size/type validation, progress/status, error handling, and controlled/uncontrolled modes
> - New `StatusBadge` with variant styling for document states and sizes
> - Legal Holds: title cell now falls back to `hold.name` when `hold.title` is missing
> - Retention: retention period now uses `retention_period_days ?? retention_days` before formatting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d81fd6b97e018e80e9f051963966986a65eeb82e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->