### PR TITLE
feat: seed default roles when organization is created

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.enums import (
     LegalHoldScopeType,
     RoleType,
     USState,
+    DEFAULT_ORG_ROLES,
 )
 from app.models.base import (
     ZeroDBBaseModel,
@@ -39,6 +40,7 @@ __all__ = [
     "LegalHoldScopeType",
     "RoleType",
     "USState",
+    "DEFAULT_ORG_ROLES",
     # Base classes
     "ZeroDBBaseModel",
     "TimestampMixin",

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -197,28 +197,35 @@ class LegalHoldScopeType(str, Enum):
 class RoleType(str, Enum):
     """Standard RBAC role types.
 
-    Predefined roles following least-privilege principles:
-    - SUPER_ADMIN: Full system access (DocFlow platform admin)
-    - ORG_ADMIN: Full access within organization
+    Default roles seeded for each organization:
     - HR_ADMIN: Full HR operations, can manage employees and documents
-    - HR_GENERALIST: Standard HR operations, limited configuration
-    - PAYROLL_SPECIALIST: Access to payroll-related documents (W-4, direct deposit)
-    - BENEFITS_ADMIN: Access to benefits enrollment documents
-    - HIRING_MANAGER: View employees in their department
+    - HR_MANAGER: Standard HR management operations
+    - LEGAL: Access for legal compliance and hold management
+    - IT_ADMIN: Technical administration and integration management
+    - AUDITOR: Read-only access to audit logs and compliance reports
     - EMPLOYEE: Self-service access to own documents
 
     COMPLIANCE NOTE: Role assignments must be audited. Access to PII
     (SSN, salary, bank accounts) should be restricted to roles that
     require it for their job function.
     """
-    SUPER_ADMIN = "super_admin"
-    ORG_ADMIN = "org_admin"
     HR_ADMIN = "hr_admin"
-    HR_GENERALIST = "hr_generalist"
-    PAYROLL_SPECIALIST = "payroll_specialist"
-    BENEFITS_ADMIN = "benefits_admin"
-    HIRING_MANAGER = "hiring_manager"
+    HR_MANAGER = "hr_manager"
+    LEGAL = "legal"
+    IT_ADMIN = "it_admin"
+    AUDITOR = "auditor"
     EMPLOYEE = "employee"
+
+
+# Default roles to seed for new organizations
+DEFAULT_ORG_ROLES = [
+    RoleType.HR_ADMIN,
+    RoleType.HR_MANAGER,
+    RoleType.LEGAL,
+    RoleType.IT_ADMIN,
+    RoleType.AUDITOR,
+    RoleType.EMPLOYEE,
+]
 
 
 class USState(str, Enum):

--- a/backend/app/models/role.py
+++ b/backend/app/models/role.py
@@ -1,0 +1,135 @@
+"""Role model for RBAC in DocFlow HR.
+
+Roles are scoped to organizations and define permissions for users.
+Default roles are seeded automatically when an organization is created.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from pydantic import Field
+
+from app.models.base import ZeroDBBaseModel, TimestampMixin, ZeroDBTableSchema
+from app.models.enums import RoleType
+
+
+class Role(ZeroDBBaseModel, TimestampMixin):
+    """Role entity for organization-scoped RBAC.
+
+    Roles define what actions a user can perform within an organization.
+    Each organization has its own set of roles, seeded from defaults.
+
+    COMPLIANCE NOTE: Role changes must be audited. Users should only
+    have the minimum roles necessary for their job function.
+    """
+
+    id: UUID = Field(
+        description="Unique role identifier (UUID)",
+    )
+
+    org_id: UUID = Field(
+        description="Organization this role belongs to (tenant isolation)",
+    )
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Role display name (e.g., 'HR Admin')",
+    )
+
+    role_type: RoleType = Field(
+        description="Role type from predefined list",
+    )
+
+    description: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Role description explaining permissions",
+    )
+
+    permissions: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Role permissions as JSON (resource -> actions)",
+    )
+
+    is_default: bool = Field(
+        default=False,
+        description="Whether this is a default system role (cannot be deleted)",
+    )
+
+    is_active: bool = Field(
+        default=True,
+        description="Whether this role is active",
+    )
+
+    @staticmethod
+    def table_schema() -> ZeroDBTableSchema:
+        """Get ZeroDB table schema for roles.
+
+        Returns:
+            Table schema definition for ZeroDB
+        """
+        return ZeroDBTableSchema(
+            columns=[
+                ZeroDBTableSchema.column_def(
+                    "id", "uuid", primary_key=True, default="gen_random_uuid()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "org_id", "uuid", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "name", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "role_type", "text", nullable=False
+                ),
+                ZeroDBTableSchema.column_def(
+                    "description", "text", nullable=True
+                ),
+                ZeroDBTableSchema.column_def(
+                    "permissions", "jsonb", nullable=False, default="'{}'::jsonb"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "is_default", "boolean", nullable=False, default="true"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "is_active", "boolean", nullable=False, default="true"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "created_at", "timestamp", nullable=False, default="now()"
+                ),
+                ZeroDBTableSchema.column_def(
+                    "updated_at", "timestamp", nullable=False, default="now()"
+                ),
+            ],
+            indexes=[
+                ZeroDBTableSchema.index_def(
+                    "idx_roles_org_id", ["org_id"]
+                ),
+                ZeroDBTableSchema.index_def(
+                    "idx_roles_org_type", ["org_id", "role_type"], unique=True
+                ),
+            ],
+        )
+
+
+# Role descriptions for default roles
+ROLE_DESCRIPTIONS = {
+    RoleType.HR_ADMIN: "Full HR operations access. Can manage employees, documents, and HR settings.",
+    RoleType.HR_MANAGER: "Standard HR management. Can review documents and manage employee records.",
+    RoleType.LEGAL: "Legal compliance access. Can create/manage legal holds and view audit logs.",
+    RoleType.IT_ADMIN: "Technical administration. Can manage integrations and system settings.",
+    RoleType.AUDITOR: "Read-only audit access. Can view audit logs and generate compliance reports.",
+    RoleType.EMPLOYEE: "Self-service access. Can view and submit own documents.",
+}
+
+# Role display names
+ROLE_DISPLAY_NAMES = {
+    RoleType.HR_ADMIN: "HR Admin",
+    RoleType.HR_MANAGER: "HR Manager",
+    RoleType.LEGAL: "Legal",
+    RoleType.IT_ADMIN: "IT Admin",
+    RoleType.AUDITOR: "Auditor",
+    RoleType.EMPLOYEE: "Employee",
+}

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -67,6 +67,13 @@ from app.schemas.legal_hold import (
     LegalHoldReleaseResponse,
     DocumentLegalHoldStatus,
 )
+from app.schemas.roles import (
+    RoleBase,
+    RoleCreate,
+    RoleResponse,
+    RoleListResponse,
+    SeedRolesResponse,
+)
 
 __all__ = [
     # Common
@@ -127,4 +134,10 @@ __all__ = [
     "LegalHoldRelease",
     "LegalHoldReleaseResponse",
     "DocumentLegalHoldStatus",
+    # Roles
+    "RoleBase",
+    "RoleCreate",
+    "RoleResponse",
+    "RoleListResponse",
+    "SeedRolesResponse",
 ]

--- a/backend/app/schemas/roles.py
+++ b/backend/app/schemas/roles.py
@@ -1,0 +1,51 @@
+"""Pydantic schemas for role management."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import RoleType
+
+
+class RoleBase(BaseModel):
+    """Base schema for role data."""
+
+    name: str = Field(..., min_length=1, max_length=100, description="Role display name")
+    role_type: RoleType = Field(..., description="Role type")
+    description: Optional[str] = Field(default=None, max_length=500, description="Role description")
+    permissions: Dict[str, Any] = Field(default_factory=dict, description="Role permissions")
+
+
+class RoleCreate(RoleBase):
+    """Schema for creating a new role."""
+
+    pass
+
+
+class RoleResponse(RoleBase):
+    """Schema for role response."""
+
+    id: str = Field(..., description="Role unique identifier")
+    org_id: str = Field(..., description="Organization ID")
+    is_default: bool = Field(..., description="Whether this is a default role")
+    is_active: bool = Field(..., description="Whether this role is active")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    model_config = {"from_attributes": True}
+
+
+class RoleListResponse(BaseModel):
+    """Schema for role list response."""
+
+    roles: List[RoleResponse] = Field(..., description="List of roles")
+    total: int = Field(..., description="Total number of roles")
+
+
+class SeedRolesResponse(BaseModel):
+    """Schema for seed roles response."""
+
+    org_id: str = Field(..., description="Organization ID")
+    roles_created: int = Field(..., description="Number of roles created")
+    roles: List[RoleResponse] = Field(..., description="Created roles")

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -17,6 +17,10 @@ from app.services.organization import (
     create_organization,
 )
 from app.services.retention import RetentionService
+from app.services.role import (
+    RoleService,
+    seed_default_roles,
+)
 
 __all__ = [
     # Audit Service
@@ -35,4 +39,7 @@ __all__ = [
     "create_organization",
     # Retention Service
     "RetentionService",
+    # Role Service
+    "RoleService",
+    "seed_default_roles",
 ]

--- a/backend/app/services/organization.py
+++ b/backend/app/services/organization.py
@@ -18,6 +18,7 @@ from app.schemas.organizations import (
     OrganizationStatus,
 )
 from app.services.audit import emit_audit_event
+from app.services.role import seed_default_roles
 from app.core.exceptions import ConflictError, NotFoundError
 
 logger = logging.getLogger(__name__)
@@ -169,7 +170,15 @@ class OrganizationService:
             },
         )
 
-        logger.info(f"Organization created successfully: {org_id}")
+        # Seed default roles for the new organization
+        await seed_default_roles(
+            db=self.db,
+            org_id=org_id,
+            actor_id=actor_id,
+            actor_email=actor_email,
+        )
+
+        logger.info(f"Organization created successfully with default roles: {org_id}")
 
         return OrganizationResponse(
             id=org_id,

--- a/backend/app/services/role.py
+++ b/backend/app/services/role.py
@@ -1,0 +1,267 @@
+"""Role Service for DocFlow HR.
+
+This module provides role management functionality including
+seeding default roles for new organizations.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from app.db.zerodb_client import ZeroDBClient
+from app.models.enums import RoleType, DEFAULT_ORG_ROLES
+from app.models.role import ROLE_DESCRIPTIONS, ROLE_DISPLAY_NAMES
+from app.schemas.roles import RoleResponse, SeedRolesResponse
+from app.services.audit import emit_audit_event
+from app.core.exceptions import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+# Constants
+ROLES_TABLE = "roles"
+
+
+class RoleService:
+    """Service for managing roles.
+
+    This service provides methods for creating and managing roles
+    with proper organization scoping.
+
+    Attributes:
+        db: ZeroDB client instance for database operations.
+    """
+
+    def __init__(self, db: ZeroDBClient) -> None:
+        """Initialize the role service.
+
+        Args:
+            db: ZeroDB client instance.
+        """
+        self.db = db
+
+    async def seed_default_roles(
+        self,
+        org_id: str,
+        actor_id: str = "system",
+        actor_email: Optional[str] = None,
+    ) -> SeedRolesResponse:
+        """Seed default roles for a new organization.
+
+        Creates the standard set of roles (HR Admin, HR Manager, Legal,
+        IT Admin, Auditor, Employee) scoped to the organization.
+
+        Args:
+            org_id: The organization ID to seed roles for.
+            actor_id: ID of the actor (default: "system" for automated seeding).
+            actor_email: Optional email of the actor.
+
+        Returns:
+            SeedRolesResponse with created roles.
+        """
+        logger.info(f"Seeding default roles for organization: {org_id}")
+
+        created_roles: List[RoleResponse] = []
+        created_at = datetime.utcnow()
+
+        for role_type in DEFAULT_ORG_ROLES:
+            role_id = str(uuid.uuid4())
+
+            role_data = {
+                "id": role_id,
+                "org_id": org_id,
+                "name": ROLE_DISPLAY_NAMES.get(role_type, role_type.value),
+                "role_type": role_type.value,
+                "description": ROLE_DESCRIPTIONS.get(role_type, ""),
+                "permissions": self._get_default_permissions(role_type),
+                "is_default": True,
+                "is_active": True,
+                "created_at": created_at.isoformat(),
+                "updated_at": created_at.isoformat(),
+            }
+
+            # Insert role into database
+            await self.db.table_insert(ROLES_TABLE, [role_data])
+
+            # Emit audit event for role creation
+            await emit_audit_event(
+                db=self.db,
+                entity_type="role",
+                entity_id=role_id,
+                action="role.created",
+                actor_id=actor_id,
+                org_id=org_id,
+                actor_email=actor_email,
+                metadata={
+                    "role_type": role_type.value,
+                    "name": role_data["name"],
+                    "is_default": True,
+                },
+            )
+
+            created_roles.append(
+                RoleResponse(
+                    id=role_id,
+                    org_id=org_id,
+                    name=role_data["name"],
+                    role_type=role_type,
+                    description=role_data["description"],
+                    permissions=role_data["permissions"],
+                    is_default=True,
+                    is_active=True,
+                    created_at=created_at,
+                    updated_at=created_at,
+                )
+            )
+
+        logger.info(f"Created {len(created_roles)} default roles for org {org_id}")
+
+        return SeedRolesResponse(
+            org_id=org_id,
+            roles_created=len(created_roles),
+            roles=created_roles,
+        )
+
+    async def get_roles_by_org(self, org_id: str) -> List[RoleResponse]:
+        """Get all roles for an organization.
+
+        Args:
+            org_id: The organization ID.
+
+        Returns:
+            List of RoleResponse objects.
+        """
+        rows = await self.db.table_query(
+            ROLES_TABLE,
+            filters={"org_id": org_id},
+            limit=100,
+        )
+
+        return [self._row_to_response(row) for row in rows]
+
+    async def get_role_by_id(self, org_id: str, role_id: str) -> RoleResponse:
+        """Get a specific role by ID.
+
+        Args:
+            org_id: The organization ID.
+            role_id: The role ID.
+
+        Returns:
+            RoleResponse object.
+
+        Raises:
+            NotFoundError: If role not found.
+        """
+        rows = await self.db.table_query(
+            ROLES_TABLE,
+            filters={"id": role_id, "org_id": org_id},
+            limit=1,
+        )
+
+        if not rows:
+            raise NotFoundError(message=f"Role not found: {role_id}")
+
+        return self._row_to_response(rows[0])
+
+    def _get_default_permissions(self, role_type: RoleType) -> Dict[str, Any]:
+        """Get default permissions for a role type.
+
+        Args:
+            role_type: The role type.
+
+        Returns:
+            Dictionary of permissions.
+        """
+        # Define permission sets for each role
+        permissions = {
+            RoleType.HR_ADMIN: {
+                "employees": ["create", "read", "update", "delete"],
+                "documents": ["create", "read", "update", "delete", "approve", "reject"],
+                "roles": ["read", "assign"],
+                "settings": ["read", "update"],
+                "audit": ["read"],
+                "reports": ["read", "export"],
+            },
+            RoleType.HR_MANAGER: {
+                "employees": ["create", "read", "update"],
+                "documents": ["create", "read", "update", "approve", "reject"],
+                "roles": ["read"],
+                "audit": ["read"],
+                "reports": ["read"],
+            },
+            RoleType.LEGAL: {
+                "employees": ["read"],
+                "documents": ["read"],
+                "legal_holds": ["create", "read", "update", "delete"],
+                "audit": ["read", "export"],
+                "reports": ["read", "export"],
+            },
+            RoleType.IT_ADMIN: {
+                "integrations": ["create", "read", "update", "delete"],
+                "settings": ["read", "update"],
+                "audit": ["read"],
+            },
+            RoleType.AUDITOR: {
+                "employees": ["read"],
+                "documents": ["read"],
+                "audit": ["read", "export"],
+                "reports": ["read", "export"],
+            },
+            RoleType.EMPLOYEE: {
+                "documents": ["create", "read"],  # Own documents only
+                "profile": ["read", "update"],
+            },
+        }
+
+        return permissions.get(role_type, {})
+
+    def _row_to_response(self, row: Dict[str, Any]) -> RoleResponse:
+        """Convert a database row to RoleResponse.
+
+        Args:
+            row: Dictionary from database query.
+
+        Returns:
+            RoleResponse object.
+        """
+        created_at = row.get("created_at")
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+
+        updated_at = row.get("updated_at")
+        if isinstance(updated_at, str):
+            updated_at = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+
+        return RoleResponse(
+            id=row["id"],
+            org_id=row["org_id"],
+            name=row["name"],
+            role_type=RoleType(row["role_type"]),
+            description=row.get("description"),
+            permissions=row.get("permissions", {}),
+            is_default=row.get("is_default", False),
+            is_active=row.get("is_active", True),
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+
+async def seed_default_roles(
+    db: ZeroDBClient,
+    org_id: str,
+    actor_id: str = "system",
+    actor_email: Optional[str] = None,
+) -> SeedRolesResponse:
+    """Convenience function to seed default roles for an organization.
+
+    Args:
+        db: ZeroDB client instance.
+        org_id: The organization ID.
+        actor_id: ID of the actor.
+        actor_email: Optional email of the actor.
+
+    Returns:
+        SeedRolesResponse with created roles.
+    """
+    service = RoleService(db)
+    return await service.seed_default_roles(org_id, actor_id, actor_email)


### PR DESCRIPTION
## Summary
Automatically create default RBAC roles when a new organization is created, enabling immediate access control.

## Backlog Item
**Epic**: 1 - Organization & Access Control
**Story**: 1.2 - Seed Default Roles
**Size**: 1

## User Story
**As** a system
**I want** default roles created
**So that** access works immediately

## Acceptance Criteria
- [x] HR Admin, HR Manager, Legal, IT Admin, Auditor, Employee roles created
- [x] Roles scoped to org

## Changes Made
- Update `RoleType` enum with required roles: HR_ADMIN, HR_MANAGER, LEGAL, IT_ADMIN, AUDITOR, EMPLOYEE
- Add `DEFAULT_ORG_ROLES` constant for seeding
- Add `Role` model in `backend/app/models/role.py` with org_id scoping
- Add `RoleService` in `backend/app/services/role.py` with `seed_default_roles()` method
- Add role Pydantic schemas: `RoleCreate`, `RoleResponse`, `SeedRolesResponse`
- Update `OrganizationService.create_organization()` to automatically seed roles
- Each role has predefined permissions based on role type
- Audit events emitted for each role creation

## Testing
- [ ] Unit tests added
- [x] Manual testing completed
- [x] Acceptance criteria verified