### PR TITLE
feat: add document schemas and service with metadata support

### DIFF
--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -1,0 +1,231 @@
+"""Pydantic schemas for Document management."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DocumentStatus(str, Enum):
+    """Document lifecycle status."""
+
+    PENDING = "pending"
+    NEEDS_REVIEW = "needs_review"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+    ARCHIVED = "archived"
+
+
+class DocumentCategory(str, Enum):
+    """Document category types."""
+
+    I9 = "i9"
+    W4 = "w4"
+    DIRECT_DEPOSIT = "direct_deposit"
+    TAX_FORM = "tax_form"
+    IDENTIFICATION = "identification"
+    CERTIFICATION = "certification"
+    LICENSE = "license"
+    POLICY_ACKNOWLEDGMENT = "policy_acknowledgment"
+    BENEFITS = "benefits"
+    PERFORMANCE = "performance"
+    OTHER = "other"
+
+
+class SubmissionChannel(str, Enum):
+    """How the document was submitted."""
+
+    UPLOAD = "upload"
+    EMAIL = "email"
+    SMS = "sms"
+    FAX = "fax"
+    CLOUD_STORAGE = "cloud_storage"
+    HRIS_SYNC = "hris_sync"
+
+
+class DocumentMetadata(BaseModel):
+    """Metadata associated with a document."""
+
+    issue_date: Optional[datetime] = Field(
+        default=None,
+        description="Date the document was issued",
+    )
+    expiration_date: Optional[datetime] = Field(
+        default=None,
+        description="Date the document expires (for licenses, certifications, etc.)",
+    )
+    issuer: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        description="Entity that issued the document",
+    )
+    document_number: Optional[str] = Field(
+        default=None,
+        max_length=100,
+        description="Document reference number (license #, certificate #, etc.)",
+    )
+    state: Optional[str] = Field(
+        default=None,
+        max_length=2,
+        description="State code if applicable (e.g., CA, NY)",
+    )
+    country: Optional[str] = Field(
+        default=None,
+        max_length=3,
+        description="Country code (ISO 3166-1 alpha-3)",
+    )
+    custom_fields: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Custom metadata fields as key-value pairs",
+    )
+
+
+class DocumentCreate(BaseModel):
+    """Schema for creating a new document."""
+
+    employee_id: str = Field(
+        ...,
+        description="ID of the employee this document belongs to",
+    )
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Document name/title",
+    )
+    category: DocumentCategory = Field(
+        default=DocumentCategory.OTHER,
+        description="Document category",
+    )
+    file_name: str = Field(
+        ...,
+        description="Original filename",
+    )
+    file_type: str = Field(
+        ...,
+        description="MIME type of the file",
+    )
+    file_size: int = Field(
+        ...,
+        ge=0,
+        description="File size in bytes",
+    )
+    storage_path: str = Field(
+        ...,
+        description="Path to file in storage",
+    )
+    submission_channel: SubmissionChannel = Field(
+        default=SubmissionChannel.UPLOAD,
+        description="How the document was submitted",
+    )
+    metadata: Optional[DocumentMetadata] = Field(
+        default=None,
+        description="Document metadata",
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        max_length=1000,
+        description="Notes about the document",
+    )
+
+
+class DocumentUpdate(BaseModel):
+    """Schema for updating a document."""
+
+    name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        description="Document name/title",
+    )
+    category: Optional[DocumentCategory] = Field(
+        default=None,
+        description="Document category",
+    )
+    status: Optional[DocumentStatus] = Field(
+        default=None,
+        description="Document status",
+    )
+    metadata: Optional[DocumentMetadata] = Field(
+        default=None,
+        description="Document metadata",
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        max_length=1000,
+        description="Notes about the document",
+    )
+
+
+class Document(BaseModel):
+    """Full document schema for responses."""
+
+    id: str = Field(..., description="Unique document ID")
+    org_id: str = Field(..., description="Organization ID")
+    employee_id: str = Field(..., description="Employee ID")
+    name: str = Field(..., description="Document name")
+    category: str = Field(..., description="Document category")
+    status: str = Field(..., description="Document status")
+    file_name: str = Field(..., description="Original filename")
+    file_type: str = Field(..., description="MIME type")
+    file_size: int = Field(..., description="File size in bytes")
+    storage_path: str = Field(..., description="Storage path")
+    submission_channel: str = Field(..., description="Submission channel")
+
+    # Metadata fields (flattened for convenience)
+    issue_date: Optional[datetime] = Field(default=None)
+    expiration_date: Optional[datetime] = Field(default=None)
+    issuer: Optional[str] = Field(default=None)
+    document_number: Optional[str] = Field(default=None)
+    metadata: Optional[Dict[str, Any]] = Field(default=None, description="Full metadata object")
+
+    # Review fields
+    reviewed_by: Optional[str] = Field(default=None)
+    reviewed_by_name: Optional[str] = Field(default=None)
+    reviewed_at: Optional[datetime] = Field(default=None)
+    review_notes: Optional[str] = Field(default=None)
+    rejection_reason: Optional[str] = Field(default=None)
+
+    # Timestamps
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: Optional[datetime] = Field(default=None)
+    submitted_at: Optional[datetime] = Field(default=None)
+
+    # Versioning
+    version: int = Field(default=1, description="Document version number")
+
+    class Config:
+        from_attributes = True
+
+
+class DocumentListResponse(BaseModel):
+    """Paginated response for document list."""
+
+    documents: List[Document] = Field(..., description="List of documents")
+    total: int = Field(..., ge=0, description="Total count")
+    page: int = Field(..., ge=1, description="Current page")
+    page_size: int = Field(..., ge=1, le=100, description="Page size")
+    has_next: bool = Field(..., description="Has next page")
+    has_previous: bool = Field(..., description="Has previous page")
+
+
+class ExpiringDocumentResponse(BaseModel):
+    """Response for documents expiring soon."""
+
+    document_id: str = Field(..., description="Document ID")
+    document_name: str = Field(..., description="Document name")
+    employee_id: str = Field(..., description="Employee ID")
+    employee_name: Optional[str] = Field(default=None, description="Employee name")
+    category: str = Field(..., description="Document category")
+    expiration_date: datetime = Field(..., description="Expiration date")
+    days_until_expiration: int = Field(..., description="Days until expiration")
+
+
+class ExpiringDocumentsListResponse(BaseModel):
+    """List of documents expiring within a time range."""
+
+    documents: List[ExpiringDocumentResponse] = Field(...)
+    total: int = Field(..., ge=0)
+    days_ahead: int = Field(..., description="Number of days looked ahead")

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -19,6 +19,12 @@ from app.services.auth import (
     refresh_access_token,
     get_current_user,
 )
+from app.services.document import (
+    DocumentService,
+    create_document,
+    get_document,
+    get_expiring_documents,
+)
 from app.services.organization import (
     OrganizationService,
     create_organization,
@@ -51,6 +57,11 @@ __all__ = [
     "verify_magic_link",
     "refresh_access_token",
     "get_current_user",
+    # Document Service
+    "DocumentService",
+    "create_document",
+    "get_document",
+    "get_expiring_documents",
     # Organization Service
     "OrganizationService",
     "create_organization",

--- a/backend/app/services/document.py
+++ b/backend/app/services/document.py
@@ -1,0 +1,464 @@
+"""Document Service for DocFlow HR.
+
+This module provides document management functionality including:
+- Document creation with metadata
+- Document retrieval and listing
+- Metadata updates
+- Expiration tracking and alerts
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.db.zerodb_client import ZeroDBClient
+from app.schemas.document import (
+    Document,
+    DocumentCreate,
+    DocumentMetadata,
+    DocumentStatus,
+    DocumentUpdate,
+    ExpiringDocumentResponse,
+)
+from app.services.audit import emit_audit_event
+
+logger = logging.getLogger(__name__)
+
+DOCUMENTS_TABLE = "documents"
+
+
+class DocumentService:
+    """Service for managing documents and their metadata."""
+
+    def __init__(self, db: ZeroDBClient) -> None:
+        """Initialize the document service.
+
+        Args:
+            db: ZeroDB client instance.
+        """
+        self.db = db
+
+    async def create_document(
+        self,
+        data: DocumentCreate,
+        org_id: str,
+        actor_id: str,
+        actor_email: Optional[str] = None,
+    ) -> Document:
+        """Create a new document with metadata.
+
+        Args:
+            data: Document creation data.
+            org_id: Organization ID.
+            actor_id: ID of user creating the document.
+            actor_email: Email of user creating the document.
+
+        Returns:
+            The created Document.
+        """
+        document_id = str(uuid.uuid4())
+        now = datetime.utcnow()
+
+        # Build document record
+        doc_data: Dict[str, Any] = {
+            "id": document_id,
+            "org_id": org_id,
+            "employee_id": data.employee_id,
+            "name": data.name,
+            "category": data.category.value,
+            "status": DocumentStatus.NEEDS_REVIEW.value,
+            "file_name": data.file_name,
+            "file_type": data.file_type,
+            "file_size": data.file_size,
+            "storage_path": data.storage_path,
+            "submission_channel": data.submission_channel.value,
+            "notes": data.notes,
+            "version": 1,
+            "created_at": now.isoformat(),
+            "submitted_at": now.isoformat(),
+        }
+
+        # Add metadata fields if provided
+        if data.metadata:
+            metadata = data.metadata
+            if metadata.issue_date:
+                doc_data["issue_date"] = metadata.issue_date.isoformat()
+            if metadata.expiration_date:
+                doc_data["expiration_date"] = metadata.expiration_date.isoformat()
+            if metadata.issuer:
+                doc_data["issuer"] = metadata.issuer
+            if metadata.document_number:
+                doc_data["document_number"] = metadata.document_number
+            if metadata.state:
+                doc_data["state"] = metadata.state
+            if metadata.country:
+                doc_data["country"] = metadata.country
+            if metadata.custom_fields:
+                doc_data["custom_fields"] = metadata.custom_fields
+
+            # Store full metadata object for querying
+            doc_data["metadata"] = metadata.model_dump(exclude_none=True)
+
+        logger.info(f"Creating document {document_id} for employee {data.employee_id}")
+
+        # Insert into database
+        await self.db.table_insert(DOCUMENTS_TABLE, [doc_data])
+
+        # Emit audit event
+        await emit_audit_event(
+            db=self.db,
+            entity_type="document",
+            entity_id=document_id,
+            action="document.received",
+            actor_id=actor_id,
+            org_id=org_id,
+            actor_email=actor_email,
+            metadata={
+                "category": data.category.value,
+                "submission_channel": data.submission_channel.value,
+                "employee_id": data.employee_id,
+            },
+        )
+
+        return self._row_to_document(doc_data)
+
+    async def get_document(
+        self,
+        document_id: str,
+        org_id: str,
+    ) -> Optional[Document]:
+        """Get a document by ID.
+
+        Args:
+            document_id: Document ID.
+            org_id: Organization ID (for access control).
+
+        Returns:
+            Document if found, None otherwise.
+        """
+        rows = await self.db.table_query(
+            DOCUMENTS_TABLE,
+            filters={"id": document_id, "org_id": org_id},
+            limit=1,
+        )
+
+        if not rows:
+            return None
+
+        return self._row_to_document(rows[0])
+
+    async def list_documents(
+        self,
+        org_id: str,
+        employee_id: Optional[str] = None,
+        category: Optional[str] = None,
+        status: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> Tuple[List[Document], int]:
+        """List documents with filtering.
+
+        Args:
+            org_id: Organization ID.
+            employee_id: Optional filter by employee.
+            category: Optional filter by category.
+            status: Optional filter by status.
+            page: Page number.
+            page_size: Items per page.
+
+        Returns:
+            Tuple of (documents list, total count).
+        """
+        filters: Dict[str, Any] = {"org_id": org_id}
+
+        if employee_id:
+            filters["employee_id"] = employee_id
+        if category:
+            filters["category"] = category
+        if status:
+            filters["status"] = status
+
+        offset = (page - 1) * page_size
+
+        rows = await self.db.table_query(
+            DOCUMENTS_TABLE,
+            filters=filters,
+            limit=page_size,
+            offset=offset,
+        )
+
+        # Get total count
+        all_rows = await self.db.table_query(
+            DOCUMENTS_TABLE,
+            filters=filters,
+            limit=10000,
+            offset=0,
+        )
+        total = len(all_rows)
+
+        documents = [self._row_to_document(row) for row in rows]
+
+        return documents, total
+
+    async def update_document(
+        self,
+        document_id: str,
+        org_id: str,
+        data: DocumentUpdate,
+        actor_id: str,
+        actor_email: Optional[str] = None,
+    ) -> Optional[Document]:
+        """Update a document's metadata.
+
+        Args:
+            document_id: Document ID.
+            org_id: Organization ID.
+            data: Update data.
+            actor_id: ID of user making the update.
+            actor_email: Email of user making the update.
+
+        Returns:
+            Updated Document if found, None otherwise.
+        """
+        # Verify document exists
+        existing = await self.get_document(document_id, org_id)
+        if not existing:
+            return None
+
+        now = datetime.utcnow()
+        update_data: Dict[str, Any] = {"updated_at": now.isoformat()}
+
+        if data.name is not None:
+            update_data["name"] = data.name
+        if data.category is not None:
+            update_data["category"] = data.category.value
+        if data.status is not None:
+            update_data["status"] = data.status.value
+        if data.notes is not None:
+            update_data["notes"] = data.notes
+
+        # Handle metadata update
+        if data.metadata is not None:
+            metadata = data.metadata
+            if metadata.issue_date is not None:
+                update_data["issue_date"] = metadata.issue_date.isoformat()
+            if metadata.expiration_date is not None:
+                update_data["expiration_date"] = metadata.expiration_date.isoformat()
+            if metadata.issuer is not None:
+                update_data["issuer"] = metadata.issuer
+            if metadata.document_number is not None:
+                update_data["document_number"] = metadata.document_number
+            if metadata.state is not None:
+                update_data["state"] = metadata.state
+            if metadata.country is not None:
+                update_data["country"] = metadata.country
+            if metadata.custom_fields is not None:
+                update_data["custom_fields"] = metadata.custom_fields
+
+            # Update full metadata object
+            update_data["metadata"] = metadata.model_dump(exclude_none=True)
+
+        logger.info(f"Updating document {document_id}")
+
+        await self.db.table_update(
+            DOCUMENTS_TABLE,
+            filters={"id": document_id},
+            update=update_data,
+        )
+
+        # Emit audit event
+        await emit_audit_event(
+            db=self.db,
+            entity_type="document",
+            entity_id=document_id,
+            action="document.updated",
+            actor_id=actor_id,
+            org_id=org_id,
+            actor_email=actor_email,
+            metadata={"updated_fields": list(update_data.keys())},
+        )
+
+        return await self.get_document(document_id, org_id)
+
+    async def get_expiring_documents(
+        self,
+        org_id: str,
+        days_ahead: int = 30,
+    ) -> List[ExpiringDocumentResponse]:
+        """Get documents expiring within a specified number of days.
+
+        Args:
+            org_id: Organization ID.
+            days_ahead: Number of days to look ahead for expirations.
+
+        Returns:
+            List of expiring documents.
+        """
+        now = datetime.utcnow()
+        cutoff_date = now + timedelta(days=days_ahead)
+
+        # Query documents with expiration dates
+        # Note: ZeroDB may need specific query syntax for date ranges
+        rows = await self.db.table_query(
+            DOCUMENTS_TABLE,
+            filters={"org_id": org_id},
+            limit=1000,
+        )
+
+        expiring = []
+        for row in rows:
+            exp_date_str = row.get("expiration_date")
+            if not exp_date_str:
+                continue
+
+            try:
+                if isinstance(exp_date_str, str):
+                    exp_date = datetime.fromisoformat(exp_date_str.replace("Z", "+00:00"))
+                else:
+                    exp_date = exp_date_str
+
+                # Check if expires within the window and not already expired
+                if now <= exp_date.replace(tzinfo=None) <= cutoff_date:
+                    days_until = (exp_date.replace(tzinfo=None) - now).days
+
+                    expiring.append(
+                        ExpiringDocumentResponse(
+                            document_id=row["id"],
+                            document_name=row.get("name", ""),
+                            employee_id=row.get("employee_id", ""),
+                            employee_name=row.get("employee_name"),
+                            category=row.get("category", "other"),
+                            expiration_date=exp_date,
+                            days_until_expiration=days_until,
+                        )
+                    )
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Invalid expiration date for document {row.get('id')}: {e}")
+
+        # Sort by expiration date (soonest first)
+        expiring.sort(key=lambda x: x.days_until_expiration)
+
+        return expiring
+
+    async def get_expired_documents(
+        self,
+        org_id: str,
+    ) -> List[Document]:
+        """Get all expired documents.
+
+        Args:
+            org_id: Organization ID.
+
+        Returns:
+            List of expired documents.
+        """
+        now = datetime.utcnow()
+
+        rows = await self.db.table_query(
+            DOCUMENTS_TABLE,
+            filters={"org_id": org_id},
+            limit=10000,
+        )
+
+        expired = []
+        for row in rows:
+            exp_date_str = row.get("expiration_date")
+            if not exp_date_str:
+                continue
+
+            try:
+                if isinstance(exp_date_str, str):
+                    exp_date = datetime.fromisoformat(exp_date_str.replace("Z", "+00:00"))
+                else:
+                    exp_date = exp_date_str
+
+                if exp_date.replace(tzinfo=None) < now:
+                    expired.append(self._row_to_document(row))
+            except (ValueError, TypeError):
+                continue
+
+        return expired
+
+    def _row_to_document(self, row: Dict[str, Any]) -> Document:
+        """Convert a database row to a Document object.
+
+        Args:
+            row: Dictionary from database query.
+
+        Returns:
+            Document object.
+        """
+        # Parse datetime fields
+        def parse_datetime(val: Any) -> Optional[datetime]:
+            if val is None:
+                return None
+            if isinstance(val, datetime):
+                return val
+            if isinstance(val, str):
+                try:
+                    return datetime.fromisoformat(val.replace("Z", "+00:00"))
+                except ValueError:
+                    return None
+            return None
+
+        return Document(
+            id=row["id"],
+            org_id=row["org_id"],
+            employee_id=row.get("employee_id", ""),
+            name=row.get("name", ""),
+            category=row.get("category", "other"),
+            status=row.get("status", "pending"),
+            file_name=row.get("file_name", ""),
+            file_type=row.get("file_type", ""),
+            file_size=row.get("file_size", 0),
+            storage_path=row.get("storage_path", ""),
+            submission_channel=row.get("submission_channel", "upload"),
+            issue_date=parse_datetime(row.get("issue_date")),
+            expiration_date=parse_datetime(row.get("expiration_date")),
+            issuer=row.get("issuer"),
+            document_number=row.get("document_number"),
+            metadata=row.get("metadata"),
+            reviewed_by=row.get("reviewed_by"),
+            reviewed_by_name=row.get("reviewed_by_name"),
+            reviewed_at=parse_datetime(row.get("reviewed_at")),
+            review_notes=row.get("review_notes"),
+            rejection_reason=row.get("rejection_reason"),
+            created_at=parse_datetime(row.get("created_at")) or datetime.utcnow(),
+            updated_at=parse_datetime(row.get("updated_at")),
+            submitted_at=parse_datetime(row.get("submitted_at")),
+            version=row.get("version", 1),
+        )
+
+
+# Convenience functions
+async def create_document(
+    db: ZeroDBClient,
+    data: DocumentCreate,
+    org_id: str,
+    actor_id: str,
+    actor_email: Optional[str] = None,
+) -> Document:
+    """Create a new document."""
+    service = DocumentService(db)
+    return await service.create_document(data, org_id, actor_id, actor_email)
+
+
+async def get_document(
+    db: ZeroDBClient,
+    document_id: str,
+    org_id: str,
+) -> Optional[Document]:
+    """Get a document by ID."""
+    service = DocumentService(db)
+    return await service.get_document(document_id, org_id)
+
+
+async def get_expiring_documents(
+    db: ZeroDBClient,
+    org_id: str,
+    days_ahead: int = 30,
+) -> List[ExpiringDocumentResponse]:
+    """Get documents expiring soon."""
+    service = DocumentService(db)
+    return await service.get_expiring_documents(org_id, days_ahead)


### PR DESCRIPTION
## Summary
- Adds document metadata storage for tracking issue dates, expirations, and custom fields
- Provides DocumentService for CRUD operations with metadata
- Enables expiration alerts for compliance tracking

## Changes
- **Document Schemas** (`backend/app/schemas/document.py`):
  - `DocumentMetadata`: issue_date, expiration_date, issuer, document_number, custom_fields
  - `DocumentCreate`, `DocumentUpdate`: CRUD schemas
  - `Document`: Full response schema
  - `ExpiringDocumentResponse`: For expiration alerts

- **Document Service** (`backend/app/services/document.py`):
  - `create_document()`: Create with metadata
  - `get_document()`: Retrieve by ID
  - `list_documents()`: Filtered listing
  - `update_document()`: Update metadata
  - `get_expiring_documents()`: Query expiring within N days

## Metadata Fields
| Field | Type | Description |
|-------|------|-------------|
| `issue_date` | datetime | When document was issued |
| `expiration_date` | datetime | When document expires |
| `issuer` | string | Issuing entity |
| `document_number` | string | License/cert number |
| `state` | string | State code (2 char) |
| `country` | string | Country code (ISO) |
| `custom_fields` | JSON | Custom key-value pairs |

## Test plan
- [ ] Create document with metadata stores correctly
- [ ] Expiration dates are queryable
- [ ] Custom fields (JSON) work properly
- [ ] get_expiring_documents returns correct documents

Closes #23